### PR TITLE
Customize hl-line instead of hl-line-face

### DIFF
--- a/zenburn-theme.el
+++ b/zenburn-theme.el
@@ -134,7 +134,7 @@
    `(mode-line-buffer-id ((,class (:foreground ,zenburn-yellow :weight bold))))
    `(mode-line-inactive
      ((,class (:foreground ,zenburn-green-1  :background ,zenburn-bg-05))))
-   `(region ((,class (:background ,zenburn-bg-1))))
+   `(region ((,class (:background ,zenburn-bg-2))))
    `(secondary-selection ((,class (:background ,zenburn-bg+2))))
    `(trailing-whitespace ((,class (:background ,zenburn-red))))
    `(vertical-border ((,class (:foreground ,zenburn-fg))))


### PR DESCRIPTION
Customizing hl-line-face does not seem to work as it's defined as inheriting from
`highlight' in hl-line.el.

Signed-off-by: Damien Cassou damien.cassou@gmail.com
