### PR TITLE
Add c-annotation-face for C, Java, Python... annotations/decorators

### DIFF
--- a/color-theme-zenburn.el
+++ b/color-theme-zenburn.el
@@ -171,6 +171,8 @@
      (font-lock-variable-name-face ((t (:foreground ,zenburn-orange))))
      (font-lock-warning-face ((t (:inherit zenburn-warning-face))))
 
+     (c-annotation-face ((t (:inherit font-lock-constant-face))))
+
      ;;; external
 
      ;; diff

--- a/zenburn-theme.el
+++ b/zenburn-theme.el
@@ -155,6 +155,8 @@
    `(font-lock-variable-name-face ((,class (:foreground ,zenburn-orange))))
    `(font-lock-warning-face ((,class (:foreground ,zenburn-yellow-1 :weight bold :underline t))))
 
+   `(c-annotation-face ((,class (:inherit font-lock-constant-face))))
+
    ;;; external
 
    ;; diff


### PR DESCRIPTION
inherits from font-lock-constant-face, because that seems reasonable and looks good.
