### PR TITLE
Trailing whitespace face fix

### DIFF
--- a/zenburn-theme.el
+++ b/zenburn-theme.el
@@ -463,7 +463,7 @@
    `(whitespace-hspace ((,class (:background ,zenburn-bg :foreground ,zenburn-bg+1))))
    `(whitespace-tab ((,class (:background ,zenburn-bg :foreground ,zenburn-red))))
    `(whitespace-newline ((,class (:foreground ,zenburn-bg+1))))
-   `(whitespace-trailing ((,class (:foreground ,zenburn-red :background ,zenburn-bg))))
+   `(whitespace-trailing ((,class (:background ,zenburn-red))))
    `(whitespace-line ((,class (:background ,zenburn-bg-05 :foreground ,zenburn-magenta))))
    `(whitespace-space-before-tab ((,class (:background ,zenburn-orange :foreground ,zenburn-orange))))
    `(whitespace-indentation ((,class (:background ,zenburn-yellow :foreground ,zenburn-red))))


### PR DESCRIPTION
Hi, Bozhidar!

I have noticed that trailing whitespace visual highlighting is not working when using zenburn theme, so I fixed it. Zenburn used "red" color as foreground, but since whitespace is usually not visible, this foreground color change was not affecting anything.

P.S. Just in case, my whitespace style settings are:

(require 'whitespace)
(setq whitespace-style '(face trailing tabs))
