### PR TITLE
Fixed background color for magit diff highlighting

### DIFF
--- a/color-theme-zenburn.el
+++ b/color-theme-zenburn.el
@@ -341,6 +341,7 @@
      ;; magit
      (magit-section-title ((t (:inherit zenburn-strong-1-face))))
      (magit-branch ((t (:inherit zenburn-strong-2-face))))
+     (magit-item-highlight ((t (:background ,zenburn-bg-1))))
 
      ;; message-mode
      (message-cited-text-face ((t (:inherit font-lock-comment))))

--- a/zenburn-theme.el
+++ b/zenburn-theme.el
@@ -343,6 +343,7 @@
    ;; magit
    `(magit-section-title ((,class (:foreground ,zenburn-yellow :weight bold))))
    `(magit-branch ((,class (:foreground ,zenburn-orange :weight bold))))
+   `(magit-item-highlight ((,class (:background ,zenburn-bg-1))))
 
    ;; message-mode
    `(message-cited-text ((,class (:inherit font-lock-comment))))


### PR DESCRIPTION
The default background for diff highlighting in magit was extremely bright and very hard on the eyes. I changed it to the zenburn default. See the screencaps:

Before:

http://i.imgur.com/56Vm4.png

After:

http://i.imgur.com/w5AGy.png
