### PR TITLE
Revert "Fixed background color for magit diff highlighting."

### DIFF
--- a/color-theme-zenburn.el
+++ b/color-theme-zenburn.el
@@ -341,7 +341,6 @@
      ;; magit
      (magit-section-title ((t (:inherit zenburn-strong-1-face))))
      (magit-branch ((t (:inherit zenburn-strong-2-face))))
-     (magit-item-highlight ((t (:background ,zenburn-bg-1))))
 
      ;; message-mode
      (message-cited-text-face ((t (:inherit font-lock-comment))))

--- a/zenburn-theme.el
+++ b/zenburn-theme.el
@@ -347,7 +347,6 @@
    ;; magit
    `(magit-section-title ((,class (:foreground ,zenburn-yellow :weight bold))))
    `(magit-branch ((,class (:foreground ,zenburn-orange :weight bold))))
-   `(magit-item-highlight ((,class (:background ,zenburn-bg-1))))
 
    ;; message-mode
    `(message-cited-text ((,class (:inherit font-lock-comment))))


### PR DESCRIPTION
This reverts commit 2a985ac294db19327e94643eb43a38dd6289ab4b.

`magit-item-highlight` (inherits from `highlight`) has to be different
from `region` because the region is relevant in the Magit status buffer.
(The region can be staged etc. instead of the complete hunk.)
