### PR TITLE
Make whitespace-trailing visible

### DIFF
--- a/zenburn-theme.el
+++ b/zenburn-theme.el
@@ -491,7 +491,7 @@
    `(whitespace-hspace ((,class (:background ,zenburn-bg :foreground ,zenburn-bg+1))))
    `(whitespace-tab ((,class (:background ,zenburn-bg :foreground ,zenburn-red))))
    `(whitespace-newline ((,class (:foreground ,zenburn-bg+1))))
-   `(whitespace-trailing ((,class (:foreground ,zenburn-red :background ,zenburn-bg))))
+   `(whitespace-trailing ((,class (:background ,zenburn-red :foreground ,zenburn-yellow))))
    `(whitespace-line ((,class (:background ,zenburn-bg-05 :foreground ,zenburn-magenta))))
    `(whitespace-space-before-tab ((,class (:background ,zenburn-orange :foreground ,zenburn-orange))))
    `(whitespace-indentation ((,class (:background ,zenburn-yellow :foreground ,zenburn-red))))


### PR DESCRIPTION
Trailing white spaces were invisible when "space-mark" is not
specified by whitespace-style.  This change rollback the change for
this face at 5149dcc82fa6c0959d975e423f25b233f9700060 to make the face
visible even when trailing space is highlighted only by face.
