### PR TITLE
theme newsticker

### DIFF
--- a/zenburn-theme.el
+++ b/zenburn-theme.el
@@ -157,6 +157,25 @@
 
    `(c-annotation-face ((,class (:inherit font-lock-constant-face))))
 
+   ;;; newsticker
+   `(newsticker-date-face ((,class (:foreground ,zenburn-fg))))
+   `(newsticker-default-face ((,class (:foreground ,zenburn-fg))))
+   `(newsticker-enclosure-face ((,class (:foreground ,zenburn-green+3))))
+   `(newsticker-extra-face ((,class (:foreground ,zenburn-bg+2 :height 0.8))))
+   `(newsticker-feed-face ((,class (:foreground ,zenburn-fg))))
+   `(newsticker-immortal-item-face ((,class (:foreground ,zenburn-green))))
+   `(newsticker-new-item-face ((,class (:foreground ,zenburn-blue))))
+   `(newsticker-obsolete-item-face ((,class (:foreground ,zenburn-red))))
+   `(newsticker-old-item-face ((,class (:foreground ,zenburn-bg+3))))
+   `(newsticker-statistics-face ((,class (:foreground ,zenburn-fg))))
+   `(newsticker-treeview-face ((,class (:foreground ,zenburn-fg))))
+   `(newsticker-treeview-immortal-face ((,class (:foreground ,zenburn-green))))
+   `(newsticker-treeview-listwindow-face ((,class (:foreground ,zenburn-fg))))
+   `(newsticker-treeview-new-face ((,class (:foreground ,zenburn-blue :weight bold))))
+   `(newsticker-treeview-obsolete-face ((,class (:foreground ,zenburn-red))))
+   `(newsticker-treeview-old-face ((,class (:foreground ,zenburn-bg+3))))
+   `(newsticker-treeview-selection-face ((,class (:foreground ,zenburn-yellow))))
+
    ;;; external
 
    ;; full-ack


### PR DESCRIPTION
This isn't perfect - for most things I just used zenburn-fg. A regular user of newsticker might want to improve this. The main thing this patch fixes is that the default font which hopefully is a monospace font is used. newstickers default is to use sans-serif which results in information being cut of.
