### PR TITLE
helm: do not underline selection

### DIFF
--- a/zenburn-theme.el
+++ b/zenburn-theme.el
@@ -306,8 +306,8 @@
                            :background ,zenburn-bg-1
                            :weight bold
                            :box (:line-width -1 :style released-button)))))
-   `(helm-selection ((,class (:background ,zenburn-bg-1))))
-   `(helm-selection-line ((,class (:background ,zenburn-bg-1))))
+   `(helm-selection ((,class (:background ,zenburn-bg+1 :underline nil))))
+   `(helm-selection-line ((,class (:background ,zenburn-bg+1))))
    `(helm-visible-mark ((,class (:foreground ,zenburn-bg :background ,zenburn-yellow-2))))
    `(helm-candidate-number ((,class (:foreground ,zenburn-green+4 :background ,zenburn-bg-1))))
 


### PR DESCRIPTION
Instead of underlining the selection use a more visible background
color (+1 instead of -1, +2 might also be an option).  This is more
visible because it is different from the background color of section
headers.

Please note that it is unclear whether `helm-selection-line' does have
any effect at all; it appears`helm-selection' always wins.
