### PR TITLE
Rainbow delimiters mode symbol name changed in latest version?

### DIFF
--- a/zenburn-theme.el
+++ b/zenburn-theme.el
@@ -584,7 +584,7 @@
 ;; Local Variables:
 ;; no-byte-compile: t
 ;; indent-tabs-mode: nil
-;; eval: (rainbow-mode 1)
+;; eval: (rainbow-delimiters-mode 1)
 ;; End:
 
 ;;; zenburn-theme.el ends here.


### PR DESCRIPTION
After updating from melpa I'm no longer able to install the zenburn theme package with the latest rainbow-delimiters package.
