### PR TITLE
magit-item-highlight doesn't need to be bold

### DIFF
--- a/zenburn-theme.el
+++ b/zenburn-theme.el
@@ -367,7 +367,7 @@
    ;; magit
    `(magit-section-title ((,class (:foreground ,zenburn-yellow :weight bold))))
    `(magit-branch ((,class (:foreground ,zenburn-orange :weight bold))))
-   `(magit-item-highlight ((,class (:background ,zenburn-bg+1 :weight bold))))
+   `(magit-item-highlight ((,class (:background ,zenburn-bg+1))))
 
    ;; message-mode
    `(message-cited-text ((,class (:inherit font-lock-comment))))


### PR DESCRIPTION
having a lighter background color is enough

this was discussed in #53
