### PR TITLE
Org mode changes

### DIFF
--- a/zenburn-theme.el
+++ b/zenburn-theme.el
@@ -467,6 +467,8 @@
    `(org-todo ((,class (:bold t :foreground ,zenburn-red :weight bold))))
    `(org-upcoming-deadline ((,class (:inherit font-lock-keyword-face))))
    `(org-warning ((,class (:bold t :foreground ,zenburn-red :weight bold :underline nil))))
+   `(org-column ((,class (:background ,zenburn-bg-1))))
+   `(org-column-title ((,class (:background ,zenburn-bg-1 :underline t :weight bold))))
 
    ;; outline
    `(outline-8 ((,class (:inherit default))))


### PR DESCRIPTION
Change to `org-warning`

`org-warning` inherits from `font-lock-warning-faces`.  By default this includes underlining.  However this led to the agenda displaying all current and past deadline items underlined, but not underlining the `TODO` state.  Adding `:underline nil` makes current and past deadlines look similar to the other lines

Add customization for `org-column` and `org-column-title`.

These were not being customized by default so they were selecting from `gray90` `gray30` or `cyan` depending on color capabilities and background.
