### PR TITLE
make org-special-keyword less visible

### DIFF
--- a/zenburn-theme.el
+++ b/zenburn-theme.el
@@ -469,7 +469,7 @@
    `(org-scheduled ((t (:foreground ,zenburn-green+4))))
    `(org-scheduled-previously ((t (:foreground ,zenburn-red-4))))
    `(org-scheduled-today ((t (:foreground ,zenburn-blue+1))))
-   `(org-special-keyword ((t (:foreground ,zenburn-yellow-1))))
+   `(org-special-keyword ((t (:foreground ,zenburn-fg-1 :weight normal))))
    `(org-table ((t (:foreground ,zenburn-green+2))))
    `(org-tag ((t (:bold t :weight bold))))
    `(org-time-grid ((t (:foreground ,zenburn-orange))))


### PR DESCRIPTION
This face is used for things that should be _less_ visible most
prominently :PROPERTIES:

This pull request is a copy of #75 which github for some reason decided to close.
