### PR TITLE
use yellow only for real links

### DIFF
--- a/zenburn-theme.el
+++ b/zenburn-theme.el
@@ -109,7 +109,7 @@
    `(compilation-line-face ((t (:foreground ,zenburn-yellow))))
    `(compilation-line-number ((t (:foreground ,zenburn-yellow))))
    `(compilation-message-face ((t (:foreground ,zenburn-blue))))
-   `(compilation-warning-face ((t (:foreground ,zenburn-yellow-1 :weight bold :underline t))))
+   `(compilation-warning-face ((t (:foreground ,zenburn-orange :weight bold :underline t))))
 
    ;;; grep
    `(grep-context-face ((t (:foreground ,zenburn-fg))))
@@ -155,7 +155,7 @@
    `(font-lock-string-face ((t (:foreground ,zenburn-red))))
    `(font-lock-type-face ((t (:foreground ,zenburn-blue-1))))
    `(font-lock-variable-name-face ((t (:foreground ,zenburn-orange))))
-   `(font-lock-warning-face ((t (:foreground ,zenburn-yellow-1 :weight bold :underline t))))
+   `(font-lock-warning-face ((t (:foreground ,zenburn-orange :weight bold :underline t))))
 
    `(c-annotation-face ((t (:inherit font-lock-constant-face))))
 
@@ -231,10 +231,10 @@
 
    ;; flymake
    `(flymake-errline ((t (:foreground ,zenburn-red-1 :weight bold :underline t))))
-   `(flymake-warnline ((t (:foreground ,zenburn-yellow-1 :weight bold :underline t))))
+   `(flymake-warnline ((t (:foreground ,zenburn-orange :weight bold :underline t))))
 
    ;; flyspell
-   `(flyspell-duplicate ((t (:foreground ,zenburn-yellow-1 :weight bold :underline t))))
+   `(flyspell-duplicate ((t (:foreground ,zenburn-orange :weight bold :underline t))))
    `(flyspell-incorrect ((t (:foreground ,zenburn-red-1 :weight bold :underline t))))
 
    ;; erc


### PR DESCRIPTION
This is done by changing the color of link like text (like
e.g. highlighted spelling errors) from yellow to orange.  Previously
both "real" links and "link-like" text were underlined and were
yellow, making impossible to tell the difference.  Caused problems
in e.g. org-mode where one can have both links and spelling errors.
