### PR TITLE
change font-lock-warning-face's appearance

### DIFF
--- a/zenburn-theme.el
+++ b/zenburn-theme.el
@@ -156,7 +156,7 @@
    `(font-lock-string-face ((t (:foreground ,zenburn-red))))
    `(font-lock-type-face ((t (:foreground ,zenburn-blue-1))))
    `(font-lock-variable-name-face ((t (:foreground ,zenburn-orange))))
-   `(font-lock-warning-face ((t (:foreground ,zenburn-orange :weight bold :underline t))))
+   `(font-lock-warning-face ((t (:foreground ,zenburn-yellow-2 :weight bold))))
 
    `(c-annotation-face ((t (:inherit font-lock-constant-face))))
 


### PR DESCRIPTION
While I proposed the old apprearance I find it to be quite ugly and
actually changed it soon after you merged my previous suggestion.
