### PR TITLE
Solarized followup

### DIFF
--- a/zenburn-theme.el
+++ b/zenburn-theme.el
@@ -298,6 +298,10 @@ Also bind `class' to ((class color) (min-colors 89))."
      ((((supports :underline (:style wave)))
        (:underline (:style wave :color ,zenburn-orange)))
       (t (:foreground ,zenburn-orange :weight bold :underline t))))
+   `(flymake-infoline
+     ((((supports :underline (:style wave)))
+       (:underline (:style wave :color ,zenburn-green)))
+      (t (:foreground ,zenburn-green-1 :weight bold :underline t))))
 ;;;;; flyspell
    `(flyspell-duplicate
      ((((supports :underline (:style wave)))


### PR DESCRIPTION
Follow up to bbatsov/solarized-emacs#62 and bbatsov/solarized-emacs#63

I have also added the `flymake-infoline` face present in Solarized Emacs.  Don't know if that is required, seems to be from the Flymake fork.
