### PR TITLE
Reduce height of linum face

### DIFF
--- a/zenburn-theme.el
+++ b/zenburn-theme.el
@@ -461,7 +461,7 @@ Also bind `class' to ((class color) (min-colors 89))."
    `(jabber-title-medium ((t (:height 1.2 :weight bold))))
    `(jabber-title-large ((t (:height 1.3 :weight bold))))
 ;;;;; linum-mode
-   `(linum ((t (:foreground ,zenburn-green+2 :background ,zenburn-bg))))
+   `(linum ((t (:foreground ,zenburn-green+2 :background ,zenburn-bg :height 0.8))))
 ;;;;; macrostep
    `(macrostep-gensym-1
      ((t (:foreground ,zenburn-green+2 :background ,zenburn-bg-1))))


### PR DESCRIPTION
Linum appears pretty obtrusive with height set to 1. Reducing it 0.8 makes better reading.