### PR TITLE
add shell-mode faces

### DIFF
--- a/zenburn-theme.el
+++ b/zenburn-theme.el
@@ -694,6 +694,9 @@ Also bind `class' to ((class color) (min-colors 89))."
    `(rst-level-4-face ((t (:foreground ,zenburn-yellow-2))))
    `(rst-level-5-face ((t (:foreground ,zenburn-cyan))))
    `(rst-level-6-face ((t (:foreground ,zenburn-green-1))))
+;;;;; sh-mode
+   `(sh-heredoc     ((t (:foreground ,zenburn-yellow :bold t))))
+   `(sh-quoted-exec ((t (:foreground ,zenburn-red))))
 ;;;;; show-paren
    `(show-paren-mismatch ((t (:foreground ,zenburn-red-3 :background ,zenburn-bg :weight bold))))
    `(show-paren-match ((t (:foreground ,zenburn-blue-1 :background ,zenburn-bg :weight bold))))


### PR DESCRIPTION
Adds some faces for sh-mode which do not correspond to standard font-lock faces.
