### PR TITLE
AUCTeX: Don't use LightSalmon, burlywood, or OliveDrab

### DIFF
--- a/zenburn-theme.el
+++ b/zenburn-theme.el
@@ -203,6 +203,9 @@ Also bind `class' to ((class color) (min-colors 89))."
    `(font-latex-warning-face ((t (:foreground nil :inherit font-lock-warning-face))))
    `(font-latex-sectioning-5-face ((t (:foreground ,zenburn-red :weight bold ))))
    `(font-latex-sedate-face ((t (:foreground ,zenburn-yellow))))
+   `(font-latex-italic-face ((t (:foreground ,zenburn-cyan :slant italic))))
+   `(font-latex-string-face ((t (:inherit ,font-lock-string-face))))
+   `(font-latex-math-face ((t (:foreground ,zenburn-orange))))
 ;;;;; auto-complete
    `(ac-candidate-face ((t (:background ,zenburn-bg+3 :foreground ,zenburn-bg-2))))
    `(ac-selection-face ((t (:background ,zenburn-blue-4 :foreground ,zenburn-fg))))


### PR DESCRIPTION
the \textit{some text} in AucTeX was in OliveDrab which is difficult to read on zenburn background. Also included proper zenburn color for math: $x=1$ and strings: ``sting''.
