### PR TITLE
Newsticker highlighted text has bad non-zenburn background

### DIFF
--- a/zenburn-theme.el
+++ b/zenburn-theme.el
@@ -184,7 +184,7 @@ Also bind `class' to ((class color) (min-colors 89))."
    `(newsticker-treeview-new-face ((t (:foreground ,zenburn-blue :weight bold))))
    `(newsticker-treeview-obsolete-face ((t (:foreground ,zenburn-red))))
    `(newsticker-treeview-old-face ((t (:foreground ,zenburn-bg+3))))
-   `(newsticker-treeview-selection-face ((t (:foreground ,zenburn-yellow))))
+   `(newsticker-treeview-selection-face ((t (:background ,zenburn-bg-1 :foreground ,zenburn-yellow))))
 ;;;; Third-party
 ;;;;; ace-jump
    `(ace-jump-face-background


### PR DESCRIPTION
Background was very difficult to read in its default non-zenburn color: #BBBBFF for highlighted/selected item.

(see first line in screenshot)
![2013-12-28-212905_543x220_scrot](https://f.cloud.github.com/assets/619390/1818426/96701b90-7002-11e3-8ad4-9e1f81c85d20.png)
