### PR TITLE
Erc timestamp

### DIFF
--- a/zenburn-theme.el
+++ b/zenburn-theme.el
@@ -184,7 +184,7 @@ Also bind `class' to ((class color) (min-colors 89))."
    `(newsticker-treeview-new-face ((t (:foreground ,zenburn-blue :weight bold))))
    `(newsticker-treeview-obsolete-face ((t (:foreground ,zenburn-red))))
    `(newsticker-treeview-old-face ((t (:foreground ,zenburn-bg+3))))
-   `(newsticker-treeview-selection-face ((t (:foreground ,zenburn-yellow))))
+   `(newsticker-treeview-selection-face ((t (:background ,zenburn-bg-1 :foreground ,zenburn-yellow))))
 ;;;; Third-party
 ;;;;; ace-jump
    `(ace-jump-face-background
@@ -203,6 +203,9 @@ Also bind `class' to ((class color) (min-colors 89))."
    `(font-latex-warning-face ((t (:foreground nil :inherit font-lock-warning-face))))
    `(font-latex-sectioning-5-face ((t (:foreground ,zenburn-red :weight bold ))))
    `(font-latex-sedate-face ((t (:foreground ,zenburn-yellow))))
+   `(font-latex-italic-face ((t (:foreground ,zenburn-cyan :slant italic))))
+   `(font-latex-string-face ((t (:inherit ,font-lock-string-face))))
+   `(font-latex-math-face ((t (:foreground ,zenburn-orange))))
 ;;;;; auto-complete
    `(ac-candidate-face ((t (:background ,zenburn-bg+3 :foreground ,zenburn-bg-2))))
    `(ac-selection-face ((t (:background ,zenburn-blue-4 :foreground ,zenburn-fg))))


### PR DESCRIPTION
This is half the part of the pull request:#147. I think there's a point in having (slightly) different colors for the noisy login/logout messages on a channel and the time stamp, which are slightly more informative, thus helping to distinguish between the two.

See relevant part of screenshot in https://github.com/bbatsov/zenburn-emacs/pull/147#issuecomment-29056756
