### PR TITLE
use same color for git-rebase-hash as for magit-log-sha1

### DIFF
--- a/zenburn-theme.el
+++ b/zenburn-theme.el
@@ -377,6 +377,8 @@ Also bind `class' to ((class color) (min-colors 89))."
    `(git-gutter-fr:added ((t (:foreground ,zenburn-green  :weight bold))))
    `(git-gutter-fr:deleted ((t (:foreground ,zenburn-red :weight bold))))
    `(git-gutter-fr:modified ((t (:foreground ,zenburn-magenta :weight bold))))
+;;;;; git-rebase-mode
+   `(git-rebase-hash ((t (:foreground, zenburn-orange))))
 ;;;;; gnus
    `(gnus-group-mail-1 ((t (:bold t :inherit gnus-group-mail-1-empty))))
    `(gnus-group-mail-1-empty ((t (:inherit gnus-group-news-1-empty))))


### PR DESCRIPTION
These colors had differed for a long time.  Eventually I changed
`git-rebase-hash` (in git-rebase-mode.el) to match `magit-log-sha1`,
and shortly thereafter someone changed just the latter (see #158) in the theme
that I am using (this one), making these faces inconsistent again... grrrr
