### PR TITLE
magit-item-highlight: leave :bold unset

### DIFF
--- a/zenburn-theme.el
+++ b/zenburn-theme.el
@@ -590,7 +590,7 @@ Also bind `class' to ((class color) (min-colors 89))."
 ;;;;; magit
    `(magit-section-title ((t (:foreground ,zenburn-yellow :weight bold))))
    `(magit-branch ((t (:foreground ,zenburn-orange :weight bold))))
-   `(magit-item-highlight ((t (:background ,zenburn-bg+1 :bold nil))))
+   `(magit-item-highlight ((t (:background ,zenburn-bg+1))))
    `(magit-log-author ((t (:foreground, zenburn-orange))))
    `(magit-log-sha1 ((t (:foreground, zenburn-orange))))
 ;;;;; message-mode


### PR DESCRIPTION
Explicitly setting `magit-item-highlight` to nil was only necessary for
the short period during which magit highlighted the current section by
making it bold.  Since that no longer is the case the only effect of
explicitly setting the highlighted section to being not-bold is that
parts of a section loose their boldness when it is current.
