### PR TITLE
Add new color zenburn-bg+05 and use it to highlight current magit sections

### DIFF
--- a/zenburn-theme.el
+++ b/zenburn-theme.el
@@ -604,7 +604,7 @@ Also bind `class' to ((class color) (min-colors 89))."
    `(macrostep-macro-face
      ((t (:underline t))))
 ;;;;; magit
-   `(magit-item-highlight ((t (:background ,zenburn-bg+1))))
+   `(magit-item-highlight ((t (:background ,zenburn-bg+05))))
    `(magit-section-title ((t (:foreground ,zenburn-yellow :weight bold))))
    `(magit-process-ok ((t (:foreground ,zenburn-green :weight bold))))
    `(magit-process-ng ((t (:foreground ,zenburn-red :weight bold))))


### PR DESCRIPTION
I think the gap from zenburn-bg to zenburn-bg+1 is to big for "the next lighter background" to be appropriate to highlight something except for temporary selections.

But that's just what we have been doing for `magit-item-highlight` for quite some time now, and I would imagine that such a "just a bit lighter than the default" background color would be useful in other contexts too.
