### PR TITLE
Remove modification of safe-local-eval-forms

### DIFF
--- a/zenburn-theme.el
+++ b/zenburn-theme.el
@@ -1042,10 +1042,6 @@ This requires library `rainbow-mode'.")
 
 (provide-theme 'zenburn)
 
-;;;###autoload
-(add-to-list 'safe-local-eval-forms
-             '(when (require 'rainbow-mode nil t) (rainbow-mode 1)))
-
 ;; Local Variables:
 ;; no-byte-compile: t
 ;; indent-tabs-mode: nil


### PR DESCRIPTION
An installed package isn't entitled to decide for the user that certain
local variable forms are safe: instead, theme authors should accept the
forms as safe when they open the source code. The form is unrelated to the
theme's functionality, and its removal won't affect normal users.

Additionally, since many people [seem to](https://github.com/milkypostman/melpa/pull/1915#issuecomment-51720775) write new themes based on the otherwise-reasonable template provided by this theme, it would be better to avoid the spread of this
snippet. :-)

-Steve
