### PR TITLE
Add racket-mode #:keywords and symbol face custs.

### DIFF
--- a/zenburn-theme.el
+++ b/zenburn-theme.el
@@ -791,6 +791,9 @@ Also bind `class' to ((class color) (min-colors 89))."
    `(proof-tacticals-name-face ((t (:inherit font-lock-constant-face :foreground nil :background ,zenburn-bg))))
    `(proof-tactics-name-face ((t (:inherit font-lock-constant-face :foreground nil :background ,zenburn-bg))))
    `(proof-warning-face ((t (:foreground ,zenburn-bg :background ,zenburn-yellow-1))))
+;;;;; racket-mode
+   `(racket-keyword-argument-face ((t (:inherit font-lock-constant-face))))
+   `(racket-selfeval-face ((t (:inherit font-lock-type-face))))
 ;;;;; rainbow-delimiters
    `(rainbow-delimiters-depth-1-face ((t (:foreground ,zenburn-fg))))
    `(rainbow-delimiters-depth-2-face ((t (:foreground ,zenburn-green+4))))


### PR DESCRIPTION
[`racket-mode`](https://github.com/greghendershott/racket-mode/) defines additional faces for symbols, numbers and other things (like `#t` and `#f`), these clash with default zenburn colours.