### PR TITLE
Add support for new face `avy-lead-face-0'

### DIFF
--- a/zenburn-theme.el
+++ b/zenburn-theme.el
@@ -220,6 +220,8 @@ Also bind `class' to ((class color) (min-colors 89))."
 ;;;;; avy
    `(avy-background-face
      ((t (:foreground ,zenburn-fg-1 :background ,zenburn-bg :inverse-video nil))))
+   `(avy-lead-face-0
+     ((t (:foreground ,zenburn-green+3 :background ,zenburn-bg :inverse-video nil))))
    `(avy-lead-face
      ((t (:foreground ,zenburn-green+2 :background ,zenburn-bg :inverse-video nil))))
 ;;;;; company-mode


### PR DESCRIPTION
The new face was added in
https://github.com/abo-abo/avy/commit/755c25a89bf01f1ad07c6ebd1bde08e1c5474794

Since it's the color of the overlay of the first char, make it a bit
lighter than `avy-lead-face'.