### PR TITLE
Undefined variable zenburn-black in magit 2.1 face

### DIFF
--- a/zenburn-theme.el
+++ b/zenburn-theme.el
@@ -656,7 +656,7 @@ Also bind `class' to ((class color) (min-colors 89))."
    `(magit-diff-hunk-heading-selection ((t (:background ,zenburn-bg+2
                                             :foreground ,zenburn-orange))))
    `(magit-diff-lines-heading          ((t (:background ,zenburn-orange
-                                            :foreground ,zenburn-black))))
+                                            :foreground ,zenburn-bg+2))))
    `(magit-diff-context-highlight      ((t (:background ,zenburn-bg+05
                                             :foreground "grey70"))))
    `(magit-diffstat-added   ((t (:foreground ,zenburn-green+4))))


### PR DESCRIPTION
magit-diff-lines-heading references zenburn-black which is an undefined
variable. Replacing it with zenburn-bg+2 as per
https://github.com/magit/magit/blob/master/lisp/magit-diff.el#L313-L332
it appears that magit-diff-lines-heading is supposed to be the inverse
of magit-diff-hunk-heading-selection.