### PR TITLE
Support for Magit 2.1.0 has`zenburn-black` as void-variable

### DIFF
--- a/zenburn-theme.el
+++ b/zenburn-theme.el
@@ -71,6 +71,7 @@
     ("zenburn-blue-3"   . "#5C888B")
     ("zenburn-blue-4"   . "#4C7073")
     ("zenburn-blue-5"   . "#366060")
+    ("zenburn-black"    . "#000000")
     ("zenburn-magenta"  . "#DC8CC3"))
   "List of Zenburn colors.
 Each element has the form (NAME . HEX).


### PR DESCRIPTION
After upgrading packages to the newest magit version :smile: :smile:  I was getting errors for `zenburn-black` being a void variable.

It looks like #200 may be the culprit.

This is what worked for me, but I also notice that `zenburn-bg-2` has the same value.

I guess you could rename `zenburn-black` to `zenburn-bg-2` as well, but I wasn't sure -- I just thought I'd share :)