### PR TITLE
Set ivy-current-match to slightly lighter bg color

### DIFF
--- a/zenburn-theme.el
+++ b/zenburn-theme.el
@@ -575,6 +575,8 @@ Also bind `class' to ((class color) (min-colors 89))."
    `(hydra-face-blue ((t (:foreground ,zenburn-blue :background ,zenburn-bg))))
    `(hydra-face-pink ((t (:foreground ,zenburn-magenta :background ,zenburn-bg))))
    `(hydra-face-teal ((t (:foreground ,zenburn-cyan :background ,zenburn-bg))))
+;;;;; ivy-mode
+   `(ivy-current-match ((t (:background ,zenburn-bg+2))))
 ;;;;; ido-mode
    `(ido-first-match ((t (:foreground ,zenburn-yellow :weight bold))))
    `(ido-only-match ((t (:foreground ,zenburn-orange :weight bold))))


### PR DESCRIPTION
This is a nice visible color for ivy selection:
<img width="686" alt="screen shot 2015-08-22 at 5 06 25 am" src="https://cloud.githubusercontent.com/assets/302945/9417962/97432ba8-488b-11e5-89ec-fec803d69c22.png">
<img width="686" alt="screen shot 2015-08-22 at 5 06 57 am" src="https://cloud.githubusercontent.com/assets/302945/9417981/b02d6462-488b-11e5-88c2-c4ee046ec4b5.png">
