### PR TITLE
Add support for context-coloring

### DIFF
--- a/zenburn-theme.el
+++ b/zenburn-theme.el
@@ -252,6 +252,17 @@ Also bind `class' to ((class color) (min-colors 89))."
    `(circe-server-face ((t (:foreground ,zenburn-green))))
    `(circe-topic-diff-new-face ((t (:foreground ,zenburn-orange :weight bold))))
    `(circe-prompt-face ((t (:foreground ,zenburn-orange :background ,zenburn-bg :weight bold))))
+;;;;; context-coloring
+   `(context-coloring-level-0-face ((t :foreground ,zenburn-fg)))
+   `(context-coloring-level-1-face ((t :foreground ,zenburn-cyan)))
+   `(context-coloring-level-2-face ((t :foreground ,zenburn-green+4)))
+   `(context-coloring-level-3-face ((t :foreground ,zenburn-yellow)))
+   `(context-coloring-level-4-face ((t :foreground ,zenburn-orange)))
+   `(context-coloring-level-5-face ((t :foreground ,zenburn-magenta)))
+   `(context-coloring-level-6-face ((t :foreground ,zenburn-blue+1)))
+   `(context-coloring-level-7-face ((t :foreground ,zenburn-green+2)))
+   `(context-coloring-level-8-face ((t :foreground ,zenburn-yellow-2)))
+   `(context-coloring-level-9-face ((t :foreground ,zenburn-red+1)))
 ;;;;; coq
    `(coq-solve-tactics-face ((t (:foreground nil :inherit font-lock-constant-face))))
 ;;;;; ctable


### PR DESCRIPTION
I've been using the following color scheme with [context-coloring](https://github.com/jacksonrayhamilton/context-coloring) for several months. It would be beneficial if zenburn users could automatically have this color scheme set up when they use context-coloring (especially since zenburn is also featured in the screenshot for the package).

context-coloring applies colors to variables based on their scope. A rainbow illustrates increasingly-higher scope levels. The colors I choose should be unambiguous when juxtaposed against other colors in the rainbow, and against syntactic elements like comments, strings and docstrings.