### PR TITLE
More compleate avy-support, and tweak faces to be easily visible

### DIFF
--- a/zenburn-theme.el
+++ b/zenburn-theme.el
@@ -217,7 +217,7 @@ Also bind `class' to ((class color) (min-colors 89))."
    `(agda2-highlight-symbol-face ((t (:foreground ,zenburn-orange))))
    `(agda2-highlight-primitive-type-face ((t (:foreground ,zenburn-blue-1))))
    `(agda2-highlight-inductive-constructor-face ((t (:foreground ,zenburn-fg))))
-   `(agda2-highlight-coinductive-constructor-face ((t (:foreground ,zenburn-fg))))    
+   `(agda2-highlight-coinductive-constructor-face ((t (:foreground ,zenburn-fg))))
    `(agda2-highlight-datatype-face ((t (:foreground ,zenburn-blue))))
    `(agda2-highlight-function-face ((t (:foreground ,zenburn-blue))))
    `(agda2-highlight-module-face ((t (:foreground ,zenburn-blue-1))))
@@ -236,11 +236,15 @@ Also bind `class' to ((class color) (min-colors 89))."
    `(popup-isearch-match ((t (:background ,zenburn-bg :foreground ,zenburn-fg))))
 ;;;;; avy
    `(avy-background-face
-     ((t (:foreground ,zenburn-fg-1 :background ,zenburn-bg :inverse-video nil))))
-   `(avy-lead-face-0
-     ((t (:foreground ,zenburn-green+3 :background ,zenburn-bg :inverse-video nil))))
+     ((t (:foreground ,zenburn-fg :background ,zenburn-bg :inverse-video nil))))
    `(avy-lead-face
-     ((t (:foreground ,zenburn-green+2 :background ,zenburn-bg :inverse-video nil))))
+     ((t (:foreground ,zenburn-fg :background ,zenburn-red-4 :inverse-video nil))))
+   `(avy-lead-face-0
+     ((t (:foreground ,zenburn-fg :background ,zenburn-blue-5 :inverse-video nil))))
+   `(avy-lead-face-1
+     ((t (:foreground ,zenburn-fg :background ,zenburn-bg+1 :inverse-video nil))))
+   `(avy-lead-face-2
+     ((t (:foreground ,zenburn-bg :background ,zenburn-fg :inverse-video nil))))
 ;;;;; company-mode
    `(company-tooltip ((t (:foreground ,zenburn-fg :background ,zenburn-bg+1))))
    `(company-tooltip-annotation ((t (:foreground ,zenburn-orange :background ,zenburn-bg+1))))


### PR DESCRIPTION
Fixes #215.

I also added the last missing face that was not in zenburn at all, used when three characters are needed to index the jump target position.

I used the oringinal colours (red or blue bg, white fg), but their zenburn equivalent. 
I'm also happy that the third "outer" key is the most visible (just zenburn fg <-> bg inversion), as that is the one you're supposed to press first.

Example for jumping to __b__ character:
![ace_zen3](https://cloud.githubusercontent.com/assets/619390/11535942/775fd0bc-9916-11e5-8c01-92e33bb650bd.png)
