### PR TITLE
Add new company-tooltip-annotation-selection face

### DIFF
--- a/zenburn-theme.el
+++ b/zenburn-theme.el
@@ -244,6 +244,7 @@ Also bind `class' to ((class color) (min-colors 89))."
 ;;;;; company-mode
    `(company-tooltip ((t (:foreground ,zenburn-fg :background ,zenburn-bg+1))))
    `(company-tooltip-annotation ((t (:foreground ,zenburn-orange :background ,zenburn-bg+1))))
+   `(company-tooltip-annotation-selection ((t (:foreground ,zenburn-orange :background ,zenburn-bg-1))))
    `(company-tooltip-selection ((t (:foreground ,zenburn-fg :background ,zenburn-bg-1))))
    `(company-tooltip-mouse ((t (:background ,zenburn-bg-1))))
    `(company-tooltip-common ((t (:foreground ,zenburn-green+2))))


### PR DESCRIPTION
Add support for new face `company-tooltip-annotation-selection`.
With https://github.com/company-mode/company-mode/commit/e5177c91887dda193309a60c4096533ce76352f1, the annotation background needs to be set separately.

See discussion here: https://github.com/company-mode/company-mode/issues/445