### PR TITLE
Update diff-hl colors.

### DIFF
--- a/zenburn-theme.el
+++ b/zenburn-theme.el
@@ -299,10 +299,9 @@ Also bind `class' to ((class color) (min-colors 89))."
      ((,class (:background ,zenburn-bg+2 :foreground ,zenburn-fg :bold t))
       (t (:background ,zenburn-fg :foreground ,zenburn-bg :bold t))))
 ;;;;; diff-hl
-   `(diff-hl-change ((,class (:foreground ,zenburn-blue-2 :background ,zenburn-bg-05))))
-   `(diff-hl-delete ((,class (:foreground ,zenburn-red+1 :background ,zenburn-bg-05))))
-   `(diff-hl-insert ((,class (:foreground ,zenburn-green+1 :background ,zenburn-bg-05))))
-   `(diff-hl-unknown ((,class (:foreground ,zenburn-yellow :background ,zenburn-bg-05))))
+   `(diff-hl-change ((,class (:foreground ,zenburn-blue :background ,zenburn-blue-2))))
+   `(diff-hl-delete ((,class (:foreground ,zenburn-red+1 :background ,zenburn-red-1))))
+   `(diff-hl-insert ((,class (:foreground ,zenburn-green+1 :background ,zenburn-green-1))))
 ;;;;; dim-autoload
    `(dim-autoload-cookie-line ((t :foreground ,zenburn-bg+1)))
 ;;;;; dired+


### PR DESCRIPTION
- Uses different colors for a more pleasing look when `diff-hl-draw-borders`
set to true.
- Also removes `diff-hl-unknown`, which doesn't appear to be used by
diff-hl anymore.

Screenshot attached.
<img width="335" alt="zenburn-diff-hl" src="https://cloud.githubusercontent.com/assets/1082280/12431478/76074506-beaa-11e5-93c6-9b62cca6b9e6.png">
