### PR TITLE
Make selected region more distinct from the bg

### DIFF
--- a/zenburn-theme.el
+++ b/zenburn-theme.el
@@ -148,7 +148,7 @@ Also bind `class' to ((class color) (min-colors 89))."
      ((t (:foreground ,zenburn-green-1
                       :background ,zenburn-bg-05
                       :box (:line-width -1 :style released-button)))))
-   `(region ((,class (:background ,zenburn-bg-1))
+   `(region ((,class (:background ,zenburn-green+2))
              (t :inverse-video t)))
    `(secondary-selection ((t (:background ,zenburn-bg+2))))
    `(trailing-whitespace ((t (:background ,zenburn-red))))


### PR DESCRIPTION
Sometimes I find it hard, especially using expand-region, to recognise which part of the text is selected, because the region background is too similar to the actual background. Tried some solutions, green+2 seem to be a perfect fit for me.

![image](https://cloud.githubusercontent.com/assets/1312677/12680243/6bd8cac8-c6b1-11e5-85a9-7f03eea1eb3d.png)
![image](https://cloud.githubusercontent.com/assets/1312677/12680255/77c8dbc0-c6b1-11e5-9ed7-529d951d7056.png)