### PR TITLE
Add a mechanism to override a subset of the theme's colours

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,27 @@ Prelude user - you're probably already using Zenburn, since it's
 Prelude's default color theme. You can load Zenburn at any time by
 `M-x load-theme zenburn`.
 
+## Customization
+
+If you'd like to tweak the theme by changing just a few colors, you can
+do so by defining new values in the `zenburn-override-colors-alist`
+variable before loading the theme.
+
+For example, to customize just the lighter background colors, you could add
+to your init file:
+
+```elisp
+(defvar zenburn-override-colors-alist
+  '(("zenburn-bg+05" . "#282828")
+    ("zenburn-bg+1"  . "#2F2F2F")
+    ("zenburn-bg+2"  . "#3F3F3F")
+    ("zenburn-bg+3"  . "#4F4F4F")))
+(load-theme 'zenburn t)
+```
+
+To see the full list of color names you can override, consult the
+`zenburn-theme.el` source file.
+
 ## Ugly colors in the terminal Emacs version
 
 If your Emacs looks considerably uglier in a terminal (compared to the

--- a/zenburn-theme.el
+++ b/zenburn-theme.el
@@ -35,7 +35,7 @@
 
 ;;; Color Palette
 
-(defvar zenburn-colors-alist
+(defvar zenburn-default-colors-alist
   '(("zenburn-fg+1"     . "#FFFFEF")
     ("zenburn-fg"       . "#DCDCCC")
     ("zenburn-fg-1"     . "#656555")
@@ -77,6 +77,16 @@ Each element has the form (NAME . HEX).
 
 `+N' suffixes indicate a color is lighter.
 `-N' suffixes indicate a color is darker.")
+
+(defvar zenburn-override-colors-alist
+  '()
+  "Place to override default theme colors.
+
+You can override a subset of the theme's default colors by
+defining them in this alist before loading the theme.")
+
+(defvar zenburn-colors-alist
+  (append zenburn-default-colors-alist zenburn-override-colors-alist))
 
 (defmacro zenburn-with-color-variables (&rest body)
   "`let' bind all colors defined in `zenburn-colors-alist' around BODY.


### PR DESCRIPTION
If a user wants to tweak the theme by changing just a few colours, they
can now do so by defining new values for just that subset in the new
"zenburn-override-colors-alist" variable.

This improves over the previous approach of having to completely
re-specify the full list of colours, which both obscures the actual
overrides among the unchanged defaults, and risks breaking when new
colours are added to the default theme without the user updating their
definition.

For example, to tweak just the lighter background colours, a user
might add to their `init.el`:

```elisp
(defvar zenburn-override-colors-alist
  '(("zenburn-bg+05" . "#282828")
    ("zenburn-bg+1"  . "#2F2F2F")
    ("zenburn-bg+2"  . "#3F3F3F")
    ("zenburn-bg+3"  . "#4F4F4F")))
(load-theme 'zenburn t)
```
