### PR TITLE
README.md: Include pointer to MELPA howto

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ Zenburn is available in both [Marmalade](http://marmalade-repo.org)
 and [MELPA](http://melpa.org).
 Keep in mind the fact the version in the Marmalade repo may not always
 be up-to-date.
+If your Emacs has not previously been configured
+to use a third-party package repository, we thus
+recommend that you set it up to fetch packages from MELPA;
+[here are their configuration instructions.](http://melpa.org/#/getting-started)
 
 You can install `zenburn` with the following command:
 


### PR DESCRIPTION
Link to the MELPA "getting started" documentation for newcomers.

As per http://stackoverflow.com/questions/35886477/i-cant-load-an-el-package-on-emacs at least one newcomer to Emacs seemed to have trouble interpreting the instructions.  Clarify that you need to configure a third-party repo if you have not done so before.
