### PR TITLE
Add faces for org-document-* in org-mode files.

### DIFF
--- a/zenburn-theme.el
+++ b/zenburn-theme.el
@@ -888,6 +888,8 @@ Also bind `class' to ((class color) (min-colors 89))."
    `(org-mode-line-clock-overrun ((t (:foreground ,zenburn-bg :background ,zenburn-red-1))))
    `(org-ellipsis ((t (:foreground ,zenburn-yellow-1 :underline t))))
    `(org-footnote ((t (:foreground ,zenburn-cyan :underline t))))
+   `(org-document-title ((t (:foreground ,zenburn-blue))))
+   `(org-document-info ((t (:foreground ,zenburn-blue))))
    `(org-habit-ready-face ((t :background ,zenburn-green)))
    `(org-habit-alert-face ((t :background ,zenburn-yellow-1 :foreground ,zenburn-bg)))
    `(org-habit-clear-face ((t :background ,zenburn-blue-3)))


### PR DESCRIPTION
These faces correspond to some metadata in `org-mode` documents. They are currently unmodified in the theme, and default to `pale turquoise` (according to `org-faces.el`). This PR makes a very small change and updates the faces to their closest Zenburn equivalent, `zenburn-blue`, for the sake of consistency.

Before and after screenshots:

![before change](https://cloud.githubusercontent.com/assets/1448326/13800256/d73f0b4a-eafd-11e5-867e-4e248edfb989.png)
![after change](https://cloud.githubusercontent.com/assets/1448326/13800260/dd716882-eafd-11e5-8216-f6261718de55.png)

Anecdotally, I have noticed that the difference is more stark on Windows, and with other fonts/sizes.