### PR TITLE
Change the new Info-quoted face introduced in Emacs 25.1

### DIFF
--- a/zenburn-theme.el
+++ b/zenburn-theme.el
@@ -141,6 +141,8 @@ Also bind `class' to ((class color) (min-colors 89))."
    `(grep-hit-face ((t (:foreground ,zenburn-blue))))
    `(grep-match-face ((t (:foreground ,zenburn-orange :weight bold))))
    `(match ((t (:background ,zenburn-bg-1 :foreground ,zenburn-orange :weight bold))))
+;;;;; info
+   `(Info-quoted ((t (:inherit font-lock-constant-face))))
 ;;;;; isearch
    `(isearch ((t (:foreground ,zenburn-yellow-2 :weight bold :background ,zenburn-bg+2))))
    `(isearch-fail ((t (:foreground ,zenburn-fg :background ,zenburn-red-4))))


### PR DESCRIPTION
Starting with Emacs 25.1 symbol names in Info pages are displayed with a fixed-pitch font. This commit changes the Info-quoted face to use a style little more consistent with Elisp syntax highlight.