### PR TITLE
Add no match color for the Anzu mode line indicator.

### DIFF
--- a/zenburn-theme.el
+++ b/zenburn-theme.el
@@ -219,6 +219,7 @@ Also bind `class' to ((class color) (min-colors 89))."
    `(android-mode-warning-face ((t (:foreground ,zenburn-yellow))))
 ;;;;; anzu
    `(anzu-mode-line ((t (:foreground ,zenburn-cyan :weight bold))))
+   `(anzu-mode-line-no-match ((t (:foreground ,zenburn-red :weight bold))))
    `(anzu-match-1 ((t (:foreground ,zenburn-bg :background ,zenburn-green))))
    `(anzu-match-2 ((t (:foreground ,zenburn-bg :background ,zenburn-orange))))
    `(anzu-match-3 ((t (:foreground ,zenburn-bg :background ,zenburn-blue))))


### PR DESCRIPTION
New Anzu update introduced a face for the mode line indicator when there is no matches.
