### PR TITLE
Fix pop menu colors (i.e. needed in jedi)

### DIFF
--- a/zenburn-theme.el
+++ b/zenburn-theme.el
@@ -252,6 +252,8 @@ Also bind `class' to ((class color) (min-colors 89))."
    `(ac-candidate-face ((t (:background ,zenburn-bg+3 :foreground ,zenburn-bg-2))))
    `(ac-selection-face ((t (:background ,zenburn-blue-4 :foreground ,zenburn-fg))))
    `(popup-tip-face ((t (:background ,zenburn-yellow-2 :foreground ,zenburn-bg-2))))
+   `(popup-menu-mouse-face ((t (:background ,zenburn-yellow-2 :foreground ,zenburn-bg-2))))
+   `(popup-summary-face ((t (:background ,zenburn-bg+3 :foreground ,zenburn-bg-2))))
    `(popup-scroll-bar-foreground-face ((t (:background ,zenburn-blue-5))))
    `(popup-scroll-bar-background-face ((t (:background ,zenburn-bg-1))))
    `(popup-isearch-match ((t (:background ,zenburn-bg :foreground ,zenburn-fg))))


### PR DESCRIPTION
Hi Bozhidar,

I've done some minor changes to your theme in order to fix two faces related to the emacs' popup  menu. The screenshots below show the use of the popup menu in a python-mode (using [jedi](http://tkf.github.io/emacs-jedi/latest/#jedi:server-command)). Please find below the popup menus before and after the changes:

**Before**
![zenburn-before](https://cloud.githubusercontent.com/assets/16867449/21578569/f4424794-cf85-11e6-96ba-9b2e8bc60aa0.png)

**After**
![zenburn-after](https://cloud.githubusercontent.com/assets/16867449/21578570/fd440242-cf85-11e6-8f41-057ffd5a3ac3.png)

Regards,
Davide