### PR TITLE
Add support for album, artist, and mark faces for mingus.

### DIFF
--- a/zenburn-theme.el
+++ b/zenburn-theme.el
@@ -911,7 +911,11 @@ Also bind `class' to ((class color) (min-colors 89))."
    `(mingus-pausing-face ((t (:foreground ,zenburn-magenta))))
    `(mingus-playing-face ((t (:foreground ,zenburn-cyan))))
    `(mingus-playlist-face ((t (:foreground ,zenburn-cyan ))))
+   `(mingus-mark-face ((t (:bold t :foreground ,zenburn-magenta))))
    `(mingus-song-file-face ((t (:foreground ,zenburn-yellow))))
+   `(mingus-artist-face ((t (:foreground ,zenburn-cyan))))
+   `(mingus-album-face ((t (:underline t :foreground ,zenburn-red+1))))
+   `(mingus-album-stale-face ((t (:foreground ,zenburn-red+1))))
    `(mingus-stopped-face ((t (:foreground ,zenburn-red))))
 ;;;;; nav
    `(nav-face-heading ((t (:foreground ,zenburn-yellow))))


### PR DESCRIPTION
Playlist view before (default settings, album and artist faces are unthemed):

![Before](https://cloud.githubusercontent.com/assets/1448326/21596204/016dae1e-d106-11e6-8a25-58db5978e3c2.png)

And with the new album and artist faces:

![After](https://cloud.githubusercontent.com/assets/1448326/21596210/14a066de-d106-11e6-99f1-c71a39b908d6.png)

The Zenburn colours chosen in these cases are similar to the default ones provided by the package. Let me know if there is any objection to this approach.