### PR TITLE
Extend ivy faces

### DIFF
--- a/zenburn-theme.el
+++ b/zenburn-theme.el
@@ -723,6 +723,7 @@ Also bind `class' to ((class color) (min-colors 89))."
                                       :underline t :weight bold))))
 ;;;;; ivy
    `(ivy-confirm-face ((t (:foreground ,zenburn-green :background ,zenburn-bg))))
+   `(ivy-cursor ((t (:foreground ,zenburn-bg :background ,zenburn-fg))))
    `(ivy-match-required-face ((t (:foreground ,zenburn-red :background ,zenburn-bg))))
    `(ivy-remote ((t (:foreground ,zenburn-blue :background ,zenburn-bg))))
    `(ivy-subdir ((t (:foreground ,zenburn-yellow :background ,zenburn-bg))))

--- a/zenburn-theme.el
+++ b/zenburn-theme.el
@@ -723,15 +723,15 @@ Also bind `class' to ((class color) (min-colors 89))."
                                       :underline t :weight bold))))
 ;;;;; ivy
    `(ivy-confirm-face ((t (:foreground ,zenburn-green :background ,zenburn-bg))))
+   `(ivy-current-match ((t (:foreground ,zenburn-yellow :weight bold :underline t))))
    `(ivy-cursor ((t (:foreground ,zenburn-bg :background ,zenburn-fg))))
    `(ivy-match-required-face ((t (:foreground ,zenburn-red :background ,zenburn-bg))))
-   `(ivy-remote ((t (:foreground ,zenburn-blue :background ,zenburn-bg))))
-   `(ivy-subdir ((t (:foreground ,zenburn-yellow :background ,zenburn-bg))))
-   `(ivy-current-match ((t (:foreground ,zenburn-yellow :weight bold :underline t))))
    `(ivy-minibuffer-match-face-1 ((t (:background ,zenburn-bg+1))))
    `(ivy-minibuffer-match-face-2 ((t (:background ,zenburn-green-1))))
    `(ivy-minibuffer-match-face-3 ((t (:background ,zenburn-green))))
    `(ivy-minibuffer-match-face-4 ((t (:background ,zenburn-green+1))))
+   `(ivy-remote ((t (:foreground ,zenburn-blue :background ,zenburn-bg))))
+   `(ivy-subdir ((t (:foreground ,zenburn-yellow :background ,zenburn-bg))))
 ;;;;; ido-mode
    `(ido-first-match ((t (:foreground ,zenburn-yellow :weight bold))))
    `(ido-only-match ((t (:foreground ,zenburn-orange :weight bold))))


### PR DESCRIPTION
Colourise missing [ivy](https://github.com/abo-abo/swiper) face `ivy-cursor` and sort ivy faces by name.

#### Before

![2017-05-11-205450_1600x900_scrot](https://cloud.githubusercontent.com/assets/9121222/25970082/55c95794-368f-11e7-9a5c-9cf865f23329.png)

#### After

![2017-05-11-210324_1600x900_scrot](https://cloud.githubusercontent.com/assets/9121222/25970098/5c89c19a-368f-11e7-992e-f935d209c489.png)