### PR TITLE
Add sx support

### DIFF
--- a/zenburn-theme.el
+++ b/zenburn-theme.el
@@ -1220,6 +1220,20 @@ Also bind `class' to ((class color) (min-colors 89))."
    `(speedbar-selected-face ((t (:foreground ,zenburn-red))))
    `(speedbar-separator-face ((t (:foreground ,zenburn-bg :background ,zenburn-blue-1))))
    `(speedbar-tag-face ((t (:foreground ,zenburn-yellow))))
+;;;;; sx
+   `(sx-custom-button
+     ((t (:background ,zenburn-fg :foreground ,zenburn-bg-1
+          :box (:line-width 3 :style released-button) :height 0.9))))
+   `(sx-question-list-answers
+     ((t (:foreground ,zenburn-green+3
+          :height 1.0 :inherit sx-question-list-parent))))
+   `(sx-question-mode-accepted
+     ((t (:foreground ,zenburn-green+3
+          :height 1.3 :inherit sx-question-mode-title))))
+   '(sx-question-mode-content-face ((t (:inherit highlight))))
+   `(sx-question-mode-kbd-tag
+     ((t (:box (:color ,zenburn-bg-1 :line-width 3 :style released-button)
+          :height 0.9 :weight semi-bold))))
 ;;;;; tabbar
    `(tabbar-button ((t (:foreground ,zenburn-fg
                                     :background ,zenburn-bg))))


### PR DESCRIPTION
Adapt those [`sx`](https://github.com/vermiculus/sx.el) faces not based on `font-lock` ones to the `zenburn` palette.

##### Before

![2017-05-26-151428_1600x900_scrot](https://cloud.githubusercontent.com/assets/9121222/26496115/7debd916-4226-11e7-8f16-04767fda89a8.png)

##### After

![2017-05-26-151606_1600x900_scrot](https://cloud.githubusercontent.com/assets/9121222/26496126/88dd0084-4226-11e7-9297-ab88132149e9.png)