### PR TITLE
Add `go-guru` support

### DIFF
--- a/zenburn-theme.el
+++ b/zenburn-theme.el
@@ -627,6 +627,8 @@ Also bind `class' to ((class color) (min-colors 89))."
    `(gnus-signature ((t (:foreground ,zenburn-yellow))))
    `(gnus-x ((t (:background ,zenburn-fg :foreground ,zenburn-bg))))
    `(mm-uu-extract ((t (:background ,zenburn-bg-05 :foreground ,zenburn-green+1))))
+;;;;; go-guru
+   `(go-guru-hl-identifier-face ((t (:foreground ,zenburn-bg-1 :background ,zenburn-green+1))))
 ;;;;; guide-key
    `(guide-key/highlight-command-face ((t (:foreground ,zenburn-blue))))
    `(guide-key/key-face ((t (:foreground ,zenburn-green))))


### PR DESCRIPTION
This is to add support for identifier highlights in `go-guru` as per https://github.com/bbatsov/zenburn-emacs/issues/282.

I have no strong opinion on the colors. I just picked something I thought would be noticeable but not too garish. I'm happy to change it.

Also, I'm not sure whether it's recommended to continue to inherit from the `highlight` face, but that's what I did. I'm happy to change this as well.

Before:

<img width="580" alt="before" src="https://user-images.githubusercontent.com/174996/30089384-3575c832-9261-11e7-8fbc-4986d8980c00.png">

After:

<img width="580" alt="after" src="https://user-images.githubusercontent.com/174996/30089395-44cead58-9261-11e7-948f-34163df3530f.png">
