### PR TITLE
Add hackernews support

### DIFF
--- a/zenburn-theme.el
+++ b/zenburn-theme.el
@@ -631,6 +631,9 @@ Also bind `class' to ((class color) (min-colors 89))."
    `(guide-key/highlight-command-face ((t (:foreground ,zenburn-blue))))
    `(guide-key/key-face ((t (:foreground ,zenburn-green))))
    `(guide-key/prefix-command-face ((t (:foreground ,zenburn-green+1))))
+;;;;; hackernews
+   '(hackernews-comment-count-face ((t (:inherit link-visited :underline nil))))
+   '(hackernews-link-face          ((t (:inherit link         :underline nil))))
 ;;;;; helm
    `(helm-header
      ((t (:foreground ,zenburn-green


### PR DESCRIPTION
Adapt [`hackernews`](https://github.com/clarete/hackernews.el) faces to `zenburn` palette.

#### Before

![2017-09-21-191202_1680x1950_scrot](https://user-images.githubusercontent.com/9121222/30711751-9f90300c-9f01-11e7-85c5-9d6073bf7455.png)

#### After

![2017-09-21-191154_1680x1950_scrot](https://user-images.githubusercontent.com/9121222/30711765-a7ee54ae-9f01-11e7-8807-b5fba01c1455.png)