### PR TITLE
Add eww certificate support

### DIFF
--- a/zenburn-theme.el
+++ b/zenburn-theme.el
@@ -135,6 +135,9 @@ Also bind `class' to ((class color) (min-colors 89))."
    `(compilation-mode-line-run ((t (:foreground ,zenburn-yellow :weight bold))))
 ;;;;; completions
    `(completions-annotations ((t (:foreground ,zenburn-fg-1))))
+;;;;; eww
+   '(eww-invalid-certificate ((t (:inherit error))))
+   '(eww-valid-certificate   ((t (:inherit success))))
 ;;;;; grep
    `(grep-context-face ((t (:foreground ,zenburn-fg))))
    `(grep-error-face ((t (:foreground ,zenburn-red-1 :weight bold :underline t))))


### PR DESCRIPTION
Adapt `eww` certificate status faces to `zenburn` palette via standard faces.

### Valid

#### Before

![2017-10-10-011621_1600x900_scrot](https://user-images.githubusercontent.com/9121222/31363879-7452dd20-ad59-11e7-94c1-f0a086fbc7b4.png)

#### After

![2017-10-10-011655_1600x900_scrot](https://user-images.githubusercontent.com/9121222/31363893-8bf3beea-ad59-11e7-8264-8a271e62016c.png)

### Invalid

#### Before

![2017-10-10-011815_1600x900_scrot](https://user-images.githubusercontent.com/9121222/31363898-9823129c-ad59-11e7-803c-fb8d2109879c.png)

#### After

![2017-10-10-011747_1600x900_scrot](https://user-images.githubusercontent.com/9121222/31363900-9e59f52c-ad59-11e7-91c5-7bd73cc2204a.png)