### PR TITLE
Fix bright red _ and ^ in LaTeX math mode

### DIFF
--- a/zenburn-theme.el
+++ b/zenburn-theme.el
@@ -249,6 +249,7 @@ Also bind `class' to ((class color) (min-colors 89))."
    `(font-latex-italic-face ((t (:foreground ,zenburn-cyan :slant italic))))
    `(font-latex-string-face ((t (:inherit ,font-lock-string-face))))
    `(font-latex-math-face ((t (:foreground ,zenburn-orange))))
+   `(font-latex-script-char-face ((t (:foreground ,zenburn-orange))))
 ;;;;; agda-mode
    `(agda2-highlight-keyword-face ((t (:foreground ,zenburn-yellow :weight bold))))
    `(agda2-highlight-string-face ((t (:foreground ,zenburn-red))))


### PR DESCRIPTION
This sets the foreground color for "font-latex-script-char-face" to "zenburn-orange", the standard color for LaTeX math.  Before, no foreground color was set for this, resulting in bright red "_" and "^" symbols; cf. https://www.gnu.org/software/auctex/manual/auctex/Fontification-of-math.html.