### PR TITLE
Add zenburn red/green for magit diff remove/add blocks

### DIFF
--- a/zenburn-theme.el
+++ b/zenburn-theme.el
@@ -844,6 +844,12 @@ Also bind `class' to ((class color) (min-colors 89))."
    `(magit-section-highlight           ((t (:background ,zenburn-bg+05))))
    `(magit-section-heading             ((t (:foreground ,zenburn-yellow :weight bold))))
    `(magit-section-heading-selection   ((t (:foreground ,zenburn-orange :weight bold))))
+
+   `(magit-diff-added-highlight ((t (:background ,zenburn-green))))
+   `(magit-diff-removed-highlight ((t (:background ,zenburn-red-3))))
+   `(magit-diff-added ((t (:background ,zenburn-green-1))))
+   `(magit-diff-removed ((t (:background ,zenburn-red-4))))
+
    `(magit-diff-file-heading           ((t (:weight bold))))
    `(magit-diff-file-heading-highlight ((t (:background ,zenburn-bg+05  :weight bold))))
    `(magit-diff-file-heading-selection ((t (:background ,zenburn-bg+05


### PR DESCRIPTION
Not 100% sure on the colour selection, suggestions welcome!

(I've only changed the background, but [magit also changes fg colour](https://github.com/magit/magit/blob/master/lisp/magit-diff.el)).

## Before
![2017-11-08-105730_954x612_scrot](https://user-images.githubusercontent.com/619390/32543016-b9621412-c474-11e7-86ea-6335364edb8d.png)

## After
![2017-11-08-105350_948x614_scrot](https://user-images.githubusercontent.com/619390/32543034-c62a3ddc-c474-11e7-89db-3fd2098b89c2.png)
