### PR TITLE
Update git-commit faces

### DIFF
--- a/zenburn-theme.el
+++ b/zenburn-theme.el
@@ -554,7 +554,9 @@ Also bind `class' to ((class color) (min-colors 89))."
    '(git-annex-dired-annexed-unavailable ((t (:inherit error :weight normal))))
 ;;;;; git-commit
    `(git-commit-comment-action  ((,class (:foreground ,zenburn-green+1 :weight bold))))
-   `(git-commit-comment-branch  ((,class (:foreground ,zenburn-blue+1  :weight bold))))
+   `(git-commit-comment-branch  ((,class (:foreground ,zenburn-blue+1  :weight bold)))) ; obsolete
+   `(git-commit-comment-branch-local  ((,class (:foreground ,zenburn-blue+1  :weight bold))))
+   `(git-commit-comment-branch-remote ((,class (:foreground ,zenburn-green  :weight bold))))
    `(git-commit-comment-heading ((,class (:foreground ,zenburn-yellow  :weight bold))))
 ;;;;; git-gutter
    `(git-gutter:added ((t (:foreground ,zenburn-green :weight bold :inverse-video t))))


### PR DESCRIPTION
```
The old face `git-commit-comment-branch' was replaced
with two new faces `git-commit-comment-branch-local'
and `git-commit-comment-branch-remote'.

Keep the old face around for a while until "everyone"
has updated, but at least until the next `git-commit'
release.
```