### PR TITLE
Move company-quickhel to the correct section

### DIFF
--- a/zenburn-theme.el
+++ b/zenburn-theme.el
@@ -298,9 +298,6 @@ Also bind `class' to ((class color) (min-colors 89))."
    `(company-scrollbar-bg ((t (:background ,zenburn-bg+2))))
    `(company-preview ((t (:background ,zenburn-green+2))))
    `(company-preview-common ((t (:foreground ,zenburn-green+2 :background ,zenburn-bg-1))))
-;;;;; company-quickhelp
-   `(company-quickhelp-color-background ,zenburn-bg+1)
-   `(company-quickhelp-color-foreground ,zenburn-fg)
 ;;;;; bm
    `(bm-face ((t (:background ,zenburn-yellow-1 :foreground ,zenburn-bg))))
    `(bm-fringe-face ((t (:background ,zenburn-yellow-1 :foreground ,zenburn-bg))))
@@ -1398,6 +1395,9 @@ Also bind `class' to ((class color) (min-colors 89))."
 ;;;;; ansi-color
    `(ansi-color-names-vector [,zenburn-bg ,zenburn-red ,zenburn-green ,zenburn-yellow
                                           ,zenburn-blue ,zenburn-magenta ,zenburn-cyan ,zenburn-fg])
+;;;;; company-quickhelp
+   `(company-quickhelp-color-background ,zenburn-bg+1)
+   `(company-quickhelp-color-foreground ,zenburn-fg)
 ;;;;; fill-column-indicator
    `(fci-rule-color ,zenburn-bg-05)
 ;;;;; nrepl-client


### PR DESCRIPTION
They are variables, not faces, so they should go under
custom-theme-set-variables, not custom-theme-set-faces (thanks basil-conto).