### PR TITLE
Fix docs to suggest using customize-set-variable instead of defvar

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,10 +70,10 @@ to your init file:
 
 ```elisp
 (setq zenburn-override-colors-alist
-  '(("zenburn-bg+05" . "#282828")
-    ("zenburn-bg+1"  . "#2F2F2F")
-    ("zenburn-bg+2"  . "#3F3F3F")
-    ("zenburn-bg+3"  . "#4F4F4F")))
+      '(("zenburn-bg+05" . "#282828")
+        ("zenburn-bg+1"  . "#2F2F2F")
+        ("zenburn-bg+2"  . "#3F3F3F")
+        ("zenburn-bg+3"  . "#4F4F4F")))
 (load-theme 'zenburn t)
 ```
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ For example, to customize just the lighter background colors, you could add
 to your init file:
 
 ```elisp
-(defvar zenburn-override-colors-alist
+(customize-set-variable 'zenburn-override-colors-alist
   '(("zenburn-bg+05" . "#282828")
     ("zenburn-bg+1"  . "#2F2F2F")
     ("zenburn-bg+2"  . "#3F3F3F")

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ For example, to customize just the lighter background colors, you could add
 to your init file:
 
 ```elisp
-(customize-set-variable 'zenburn-override-colors-alist
+(setq zenburn-override-colors-alist
   '(("zenburn-bg+05" . "#282828")
     ("zenburn-bg+1"  . "#2F2F2F")
     ("zenburn-bg+2"  . "#3F3F3F")


### PR DESCRIPTION
In 4b3e541 the colour customization mechanism
`zenburn-override-colors-alist`was changed from a `defvar` to a
`defcustom`, which means these instructions need updating.

Fixes #302.