### PR TITLE
Fix widget-field face on 24bit color text terminals

### DIFF
--- a/zenburn-theme.el
+++ b/zenburn-theme.el
@@ -126,6 +126,7 @@ Also bind `class' to ((class color) (min-colors 89))."
    `(link-visited ((t (:foreground ,zenburn-yellow-2 :underline t :weight normal))))
    `(default ((t (:foreground ,zenburn-fg :background ,zenburn-bg))))
    `(cursor ((t (:foreground ,zenburn-fg :background ,zenburn-fg+1))))
+   `(widget-field ((t (:foreground ,zenburn-fg :background ,zenburn-bg+3))))
    `(escape-glyph ((t (:foreground ,zenburn-yellow :weight bold))))
    `(fringe ((t (:foreground ,zenburn-fg :background ,zenburn-bg+1))))
    `(header-line ((t (:foreground ,zenburn-yellow


### PR DESCRIPTION
If it's not explicitely set, the face gets an ugly yellow inherited
from the default palette which hurts the eyes (I see it constantly in
notmuch while reading e-mail).

Signed-off-by: Ioan-Adrian Ratiu <adrian.ratiu@ni.com>