### PR TITLE
Add parenthesis colour for paren-face

### DIFF
--- a/zenburn-theme.el
+++ b/zenburn-theme.el
@@ -1145,6 +1145,8 @@ Also bind `class' to ((class color) (min-colors 89))."
    `(cperl-nonoverridable-face ((t (:foreground ,zenburn-magenta))))
    `(cperl-array-face ((t (:foreground ,zenburn-yellow, :backgorund ,zenburn-bg))))
    `(cperl-hash-face ((t (:foreground ,zenburn-yellow-1, :background ,zenburn-bg))))
+;;;;; paren-face
+   `(parenthesis ((t (:foreground ,zenburn-fg-1))))
 ;;;;; perspective
    `(persp-selected-face ((t (:foreground ,zenburn-yellow-2 :inherit mode-line))))
 ;;;;; powerline
@@ -1240,7 +1242,7 @@ Also bind `class' to ((class color) (min-colors 89))."
    `(sh-quoted-exec ((t (:foreground ,zenburn-red))))
 ;;;;; show-paren
    `(show-paren-mismatch ((t (:foreground ,zenburn-red+1 :background ,zenburn-bg+3 :weight bold))))
-   `(show-paren-match ((t (:background ,zenburn-bg+3 :weight bold))))
+   `(show-paren-match ((t (:foreground ,zenburn-fg :background ,zenburn-bg+3 :weight bold))))
 ;;;;; smart-mode-line
    ;; use (setq sml/theme nil) to enable Zenburn for sml
    `(sml/global ((,class (:foreground ,zenburn-fg :weight bold))))


### PR DESCRIPTION
https://github.com/tarsius/paren-face/

The modification to show-paren-match is necessary to stop the background colour hiding the dimmed parenthesis. It does change the behaviour with, for example, rainbow-delimiters, but IMO, the effect is actually nicer this way.