### PR TITLE
Support for line-numbers-mode

### DIFF
--- a/zenburn-theme.el
+++ b/zenburn-theme.el
@@ -213,7 +213,7 @@ Also bind `class' to ((class color) (min-colors 89))."
 
    `(c-annotation-face ((t (:inherit font-lock-constant-face))))
 ;;;;; line numbers (Emacs 26.1 and above)
-   `(line-number ((t (:foreground ,zenburn-blue-3 :background ,zenburn-bg-1))))
+   `(line-number ((t (:foreground ,zenburn-bg+3 :background ,zenburn-bg-05))))
    `(line-number-current-line ((t (:inherit line-number :foreground ,zenburn-yellow-2))))
 ;;;;; man
    '(Man-overstrike ((t (:inherit font-lock-keyword-face))))

--- a/zenburn-theme.el
+++ b/zenburn-theme.el
@@ -212,6 +212,9 @@ Also bind `class' to ((class color) (min-colors 89))."
    `(font-lock-warning-face ((t (:foreground ,zenburn-yellow-2 :weight bold))))
 
    `(c-annotation-face ((t (:inherit font-lock-constant-face))))
+;;;;; line numbers (Emacs 26.1 and above)
+   `(line-number ((t (:foreground ,zenburn-blue-3 :background ,zenburn-bg-1))))
+   `(line-number-current-line ((t (:inherit line-number :foreground ,zenburn-yellow-2))))
 ;;;;; man
    '(Man-overstrike ((t (:inherit font-lock-keyword-face))))
    '(Man-underline  ((t (:inherit (font-lock-string-face underline)))))


### PR DESCRIPTION
Emacs 26.1 introduced built-in line numbers via `display-line-numbers-mode`. This adds support for related faces. I took the colors to closely match vim's zenburn.