### PR TITLE
Uncomment and fix the advices that add zenburn-specific font-lock

### DIFF
--- a/zenburn-theme.el
+++ b/zenburn-theme.el
@@ -1610,28 +1610,39 @@ Also bind `class' to ((class color) (min-colors 89))."
 
 (defvar zenburn-add-font-lock-keywords nil
   "Whether to add font-lock keywords for zenburn color names.
+
 In buffers visiting library `zenburn-theme.el' the zenburn
-specific keywords are always added.  In all other Emacs-Lisp
-buffers this variable controls whether this should be done.
-This requires library `rainbow-mode'.")
+specific keywords are always added, provided that library has
+been loaded (because that is where the code that does it is
+definded).  If you visit this file and only enable the theme,
+then you have to turn `rainbow-mode' off and on again for the
+zenburn-specific font-lock keywords to be used.
+
+In all other Emacs-Lisp buffers this variable controls whether
+this should be done.  This requires library `rainbow-mode'.")
 
 (defvar zenburn-colors-font-lock-keywords nil)
 
-;; (defadvice rainbow-turn-on (after zenburn activate)
-;;   "Maybe also add font-lock keywords for zenburn colors."
-;;   (when (and (derived-mode-p 'emacs-lisp-mode)
-;;              (or zenburn-add-font-lock-keywords
-;;                  (equal (file-name-nondirectory (buffer-file-name))
-;;                         "zenburn-theme.el")))
-;;     (unless zenburn-colors-font-lock-keywords
-;;       (setq zenburn-colors-font-lock-keywords
-;;             `((,(regexp-opt (mapcar 'car zenburn-colors-alist) 'words)
-;;                (0 (rainbow-colorize-by-assoc zenburn-colors-alist))))))
-;;     (font-lock-add-keywords nil zenburn-colors-font-lock-keywords)))
+(defun zenburn--rainbow-turn-on ()
+  "Maybe also add font-lock keywords for zenburn colors."
+  (when (and (derived-mode-p 'emacs-lisp-mode)
+             (or zenburn-add-font-lock-keywords
+                 (and (buffer-file-name)
+                      (equal (file-name-nondirectory (buffer-file-name))
+                             "zenburn-theme.el"))))
+    (unless zenburn-colors-font-lock-keywords
+      (setq zenburn-colors-font-lock-keywords
+            `((,(regexp-opt (mapcar 'car zenburn-default-colors-alist) 'words)
+               (0 (rainbow-colorize-by-assoc zenburn-default-colors-alist))))))
+    (font-lock-add-keywords nil zenburn-colors-font-lock-keywords 'end)))
 
-;; (defadvice rainbow-turn-off (after zenburn activate)
-;;   "Also remove font-lock keywords for zenburn colors."
-;;   (font-lock-remove-keywords nil zenburn-colors-font-lock-keywords))
+(defun zenburn--rainbow-turn-off ()
+  "Also remove font-lock keywords for zenburn colors."
+  (font-lock-remove-keywords nil zenburn-colors-font-lock-keywords))
+
+(when (fboundp 'advice-add)
+  (advice-add 'rainbow-turn-on :after  #'zenburn--rainbow-turn-on)
+  (advice-add 'rainbow-turn-off :after #'zenburn--rainbow-turn-off))
 
 ;;; Footer
 


### PR DESCRIPTION
For now this is just food for thought and a place to talk.

While working on fixing a regression introduced by #300 I found myself once more longing for better tooling when editing themes. Beside this I also wrote https://github.com/tarsius/kludges/blob/master/kludges.el#L30.

Anyway, don't merge this (yet?), I intend to look into implementing a generalized variant, that could be used by other themes as well.

----


I originally implemented these advices in #106.  They got commented
out in 27cee3d in response to #110 and similar reports in prelude's
issue tracker.

I just implemented the same thing again, only to find the commented
advices once I was done... five years later... it seem I would very
much like this.

So I had a look at the reports and it seems pretty obvious what the
issue was: just because the major-mode is `emacs-lisp-mode`, that
does not mean that the buffer is visiting a file.  And the fix is
to check whether the buffer is visiting a file before trying to do
something with the `buffer-file-name`.

Besides reverting the commenting and fixing the bug, this commit
also does the following:

- Use `zenburn-default-colors-alist` because that variable has since
  been renamed.

- Add out keywords at the end because otherwise the "blue" in
  "zenburn-blue" for example would have "blue" as the background color
  instead of "zenburn-blue".

- Extend the doc-string of `zenburn-add-font-lock-keywords` to make
  users aware of a complication.