### PR TITLE
Add zenburn-theme to faces Custom group

### DIFF
--- a/zenburn-theme.el
+++ b/zenburn-theme.el
@@ -35,6 +35,7 @@
 
 (defgroup zenburn-theme nil
   "Zenburn theme."
+  :group 'faces
   :prefix "zenburn-theme-"
   :link '(url-link :tag "GitHub" "http://github.com/bbatsov/zenburn-emacs")
   :tag "Zenburn theme")


### PR DESCRIPTION
While working on #315 I also tested how that interacts with byte-compiling.

Well, the first thing I learned that byte-compiling theme libraries is indeed a bad idea.

But I also got some byte-compile warnings that probably nobody has seen for a while:

```
zenburn-theme.el:36:1:Warning: defgroup for ‘zenburn-theme’ fails to specify
    containing group
zenburn-theme.el:169:1:Error: Symbol’s value as variable is void: zenburn-default-colors-alist
``` 

This commit addresses the first of these two (see below).

The second could be fixed by wrapping the respective `defvar` with `(cl-eval-when (eval load compile) ...)`, but since we *don't* byte-compile, that's not really necessary.

----

I don't think it is customary to add theme groups to any parent group,
but that's probably just because themes are usually not byte-compiled,
so the byte-compiler didn't get a chance to inform the author about
this issue.

The `faces` group seems like an obvious parent.  I wouldn't worry
about polluting that group with lots of theme sub-groups if this
catches on because for that to happen all the libraries that define
those themes would have to be loaded and if one did that, then one
would have bigger problems than to many sub-groups.

On the other hand, if one does use the `zenburn` theme (or another
theme), then it is nice to find that in `faces`.