### PR TITLE
bugfix: Update backgound color for hl-line

### DIFF
--- a/zenburn-theme.el
+++ b/zenburn-theme.el
@@ -788,9 +788,9 @@ Also bind `class' to ((class color) (min-colors 89))."
    `(helm-swoop-target-line-face ((t (:foreground ,zenburn-fg :background ,zenburn-bg+1))))
    `(helm-swoop-target-word-face ((t (:foreground ,zenburn-yellow :background ,zenburn-bg+2 :weight bold))))
 ;;;;; hl-line-mode
-   `(hl-line-face ((,class (:background ,zenburn-bg-05))
+   `(hl-line-face ((,class (:background ,zenburn-bg+2))
                    (t :weight bold)))
-   `(hl-line ((,class (:background ,zenburn-bg-05)) ; old emacsen
+   `(hl-line ((,class (:background ,zenburn-bg+2)) ; old emacsen
               (t :weight bold)))
 ;;;;; hl-sexp
    `(hl-sexp-face ((,class (:background ,zenburn-bg+1))


### PR DESCRIPTION
- Changes background color from zenburn-bg-05 to zenburn-bg+2 to make
  it visible

result:

![screen shot 2019-01-18 at 4 02 13 pm](https://user-images.githubusercontent.com/10784051/51368298-9007e380-1b3a-11e9-8070-f55de4d56edb.png)
