### PR TITLE
Theme swiper-isearch-current-match

### DIFF
--- a/zenburn-theme.el
+++ b/zenburn-theme.el
@@ -1400,6 +1400,8 @@ Also bind `class' to ((class color) (min-colors 89))."
    `(speedbar-selected-face ((t (:foreground ,zenburn-red))))
    `(speedbar-separator-face ((t (:foreground ,zenburn-bg :background ,zenburn-blue-1))))
    `(speedbar-tag-face ((t (:foreground ,zenburn-yellow))))
+;;;;; swiper
+   `(swiper-isearch-current-match ((t (:foreground ,zenburn-bg :background ,zenburn-blue-1))))
 ;;;;; sx
    `(sx-custom-button
      ((t (:background ,zenburn-fg :foreground ,zenburn-bg-1


### PR DESCRIPTION
A new face was recently added to swiper:
https://github.com/abo-abo/swiper/commit/39a9e94d530c3d209f367e1aefe313b696100248

This is how it looks without this change:

![before](https://user-images.githubusercontent.com/8199224/57505403-7dd3d000-72f8-11e9-91f6-4115d07952b3.png)

And this is with this PR applied:

![after](https://user-images.githubusercontent.com/8199224/57505418-86c4a180-72f8-11e9-9a21-abfb94882f5d.png)

I only changed the foreground colour a little, but if you need me to work on the background instead, just let me know.