### PR TITLE
Theme swiper-line-face

### DIFF
--- a/zenburn-theme.el
+++ b/zenburn-theme.el
@@ -1401,7 +1401,7 @@ Also bind `class' to ((class color) (min-colors 89))."
    `(speedbar-separator-face ((t (:foreground ,zenburn-bg :background ,zenburn-blue-1))))
    `(speedbar-tag-face ((t (:foreground ,zenburn-yellow))))
 ;;;;; swiper
-   `(swiper-isearch-current-match ((t (:foreground ,zenburn-bg :background ,zenburn-blue-1))))
+   `(swiper-line-face ((t (:underline t))))
 ;;;;; sx
    `(sx-custom-button
      ((t (:background ,zenburn-fg :foreground ,zenburn-bg-1


### PR DESCRIPTION
`swiper-isearch-current-match` has been removed from Swiper.

See: https://github.com/purcell/color-theme-sanityinc-tomorrow/pull/131