### PR TITLE
Fix hl-line-mode on Emacs 27

### DIFF
--- a/zenburn-theme.el
+++ b/zenburn-theme.el
@@ -817,7 +817,7 @@ Also bind `class' to ((class color) (min-colors 89))."
 ;;;;; hl-line-mode
    `(hl-line-face ((,class (:background ,zenburn-bg-05))
                    (t :weight bold)))
-   `(hl-line ((,class (:background ,zenburn-bg-05)) ; old emacsen
+   `(hl-line ((,class (:background ,zenburn-bg-05 :extend t)) ; old emacsen
               (t :weight bold)))
 ;;;;; hl-sexp
    `(hl-sexp-face ((,class (:background ,zenburn-bg+1))


### PR DESCRIPTION
In Emacs 27, to make a face extend to the full line, you need the extend property. This commit fixes that. More information here: https://www.reddit.com/r/emacs/comments/diahh1/emacs_27_update_changed_how_highlighted_lines/

Best regards,
Stefan Kangas

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [? - seems to be missing] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [X] You've updated the changelog (if adding/changing user-visible functionality)
- [X] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
