### PR TITLE
Fix region face on Emacs 27

### DIFF
--- a/zenburn-theme.el
+++ b/zenburn-theme.el
@@ -249,7 +249,7 @@ Also bind `class' to ((class color) (min-colors 89))."
      ((t (:foreground ,zenburn-green-2
                       :background ,zenburn-bg-05
                       :box (:line-width -1 :style released-button)))))
-   `(region ((,class (:background ,zenburn-bg-1))
+   `(region ((,class (:background ,zenburn-bg-1 :extend t))
              (t :inverse-video t)))
    `(secondary-selection ((t (:background ,zenburn-bg+2))))
    `(trailing-whitespace ((t (:background ,zenburn-red))))


### PR DESCRIPTION
Same thing as #335 but for the region face - we need to add the :extend attribute.