### PR TITLE
Remove options that do not take effect when using custom-set-variable from the customize interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ To see the full list of color names you can override, consult the
 
 The theme supports scaling the font size for some headings and titles as well
 as using a variable-pitch font for those. To enable this, use the following
-settings:
+settings before loading `zenburn-theme`:
 
 ```elisp
 ;; use variable-pitch fonts for some headings and titles

--- a/zenburn-theme.el
+++ b/zenburn-theme.el
@@ -51,11 +51,14 @@ defining them in this alist."
           :key-type (string :tag "Name")
           :value-type (string :tag " Hex")))
 
-(defcustom zenburn-use-variable-pitch nil
-  "Use variable pitch face for some headings and titles."
-  :type 'boolean
-  :group 'zenburn-theme
-  :package-version '(zenburn . "2.6"))
+(defvar zenburn-use-variable-pitch nil
+  "When non-nil, use variable pitch face for some headings and titles.")
+
+(defvar zenburn-scale-org-headlines nil
+  "Whether `org-mode' headlines should be scaled.")
+
+(defvar zenburn-scale-outline-headlines nil
+  "Whether `outline-mode' headlines should be scaled.")
 
 (defcustom zenburn-height-minus-1 0.8
   "Font size -1."
@@ -84,18 +87,6 @@ defining them in this alist."
 (defcustom zenburn-height-plus-4 1.3
   "Font size +4."
   :type 'number
-  :group 'zenburn-theme
-  :package-version '(zenburn . "2.6"))
-
-(defcustom zenburn-scale-org-headlines nil
-  "Whether `org-mode' headlines should be scaled."
-  :type 'boolean
-  :group 'zenburn-theme
-  :package-version '(zenburn . "2.6"))
-
-(defcustom zenburn-scale-outline-headlines nil
-  "Whether `outline-mode' headlines should be scaled."
-  :type 'boolean
   :group 'zenburn-theme
   :package-version '(zenburn . "2.6"))
 


### PR DESCRIPTION
The options listed below were removed from the customize interface since they don't take effect when using `custom-set-variables` as described on issue #325.

```elisp
zenburn-use-variable-pitch
zenburn-scale-org-headlines
zenburn-scale-outline-headlines
```

Also changed the docstring and the README.md to reflect this.

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../CONTRIBUTING.md)
- [ ] You've updated the changelog (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
