### PR TITLE
Change fill-column-indicator face

### DIFF
--- a/zenburn-theme.el
+++ b/zenburn-theme.el
@@ -204,7 +204,7 @@ Also bind `class' to ((class color) (min-colors 89))."
    `(custom-group-tag ((t (:foreground ,zenburn-blue :weight bold :height 1.2))))
    `(custom-state ((t (:foreground ,zenburn-green+4))))
 ;;;;; display-fill-column-indicator
-     `(fill-column-indicator ((,class :foreground ,zenburn-bg-05 :weight semilight)))
+   `(fill-column-indicator ((,class (:foreground ,zenburn-bg+2 :weight semi-light))))
 ;;;;; eww
    '(eww-invalid-certificate ((t (:inherit error))))
    '(eww-valid-certificate   ((t (:inherit success))))


### PR DESCRIPTION
Emacs 27 has `fill-column-indicator` face and `M-x display-fill-column-indicator-mode`.

Current zenburn-emacs's `fill-column-indicator` is hard to see.
I changed fill-column-indicator face.

Before:
<img width="693" alt="スクリーンショット 2020-03-23 12 18 24" src="https://user-images.githubusercontent.com/13937915/77279128-6a5d0800-6d04-11ea-8327-2e71a560eb04.png">

After:
<img width="571" alt="スクリーンショット 2020-03-23 12 40 49" src="https://user-images.githubusercontent.com/13937915/77279118-66c98100-6d04-11ea-8cc0-0a4a06fa6f62.png">


cc @tarsius  (because of https://github.com/bbatsov/zenburn-emacs/commit/efe7293a632f86e8834f14a3bc0b0cc3f82f61b8)

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
