### PR TITLE
Add tab-bar-mode and tab-line-mode support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## master (unreleased)
 
+### New features
+
+* Add `tab-bar-mode` support
+* Add `tab-line-mode` support
+
 ## 2.7 (2020-11-21)
 
 ### New features

--- a/zenburn-theme.el
+++ b/zenburn-theme.el
@@ -1477,6 +1477,14 @@ Also bind `class' to ((class color) (min-colors 89))."
    `(tabbar-unselected ((t (:foreground ,zenburn-fg
                                         :background ,zenburn-bg+1
                                         :box (:line-width -1 :style released-button)))))
+;;;;; tab-bar
+   `(tab-bar ((t (:background ,zenburn-bg+1 :foreground ,zenburn-fg+1 :box nil))))
+   `(tab-bar-tab ((t (:background ,zenburn-bg :foreground ,zenburn-fg+2 :box nil))))
+   `(tab-bar-tab-inactive ((t (:background ,zenburn-bg+1 :foreground ,zenburn-fg+1 :box nil))))
+;;;;; tab-line
+   `(tab-line ((t (:background ,zenburn-bg+1 :foreground ,zenburn-fg+1 :box nil))))
+   `(tab-line-tab-current ((t (:background ,zenburn-bg :foreground ,zenburn-fg+2 :box nil))))
+   `(tab-line-tab-inactive ((t (:background ,zenburn-bg+1 :foreground ,zenburn-fg+1 :box nil))))
 ;;;;; term
    `(term-color-black ((t (:foreground ,zenburn-bg
                                        :background ,zenburn-bg-1))))


### PR DESCRIPTION
Add basic 'tab-bar-mode` and `tab-line-mode` support.

tab-bar-mode:

Before:
![tab-bar-before](https://user-images.githubusercontent.com/32809182/125917080-96b7df11-c039-4aaf-8031-df4a8f12308f.png)

After:
![tab-bar](https://user-images.githubusercontent.com/32809182/125917099-79e73b93-13fa-4c26-87f3-d0a2017fd918.png)

tab-line-mode:

Before:
![zenburn-before](https://user-images.githubusercontent.com/32809182/120156171-4d836500-c224-11eb-9e74-e079c311007e.png)

After:
![tab-line](https://user-images.githubusercontent.com/32809182/125916770-21ad450b-ea2b-489d-a531-15d799443ed8.png)


-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [x] You've added a before/after screenshot illustrating visually your changes.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality - e.g. theme new faces/packages, changing existing faces, etc)
- [x] You've updated the readme (if adding/changing configuration options) -> No readme update

Thanks!
