### PR TITLE
Add support for vertico and orderless

### DIFF
--- a/zenburn-theme.el
+++ b/zenburn-theme.el
@@ -1189,6 +1189,11 @@ Also bind `class' to ((class color) (min-colors 89))."
    `(notmuch-tag-unread ((t (:foreground ,zenburn-red))))
    `(notmuch-tree-match-author-face ((t (:foreground ,zenburn-green+1))))
    `(notmuch-tree-match-tag-face ((t (:foreground ,zenburn-green+1))))
+;;;;; orderless
+   `(orderless-match-face-0 ((t (:foreground ,zenburn-green))))
+   `(orderless-match-face-1 ((t (:foreground ,zenburn-magenta))))
+   `(orderless-match-face-2 ((t (:foreground ,zenburn-blue))))
+   `(orderless-match-face-3 ((t (:foreground ,zenburn-orange))))
 ;;;;; org-mode
    `(org-agenda-date-today
      ((t (:foreground ,zenburn-fg+1 :slant italic :weight bold))) t)
@@ -1502,6 +1507,8 @@ Also bind `class' to ((class color) (min-colors 89))."
    `(undo-tree-visualizer-default-face ((t (:foreground ,zenburn-fg))))
    `(undo-tree-visualizer-register-face ((t (:foreground ,zenburn-yellow))))
    `(undo-tree-visualizer-unmodified-face ((t (:foreground ,zenburn-cyan))))
+;;;;; vertico
+   `(vertico-current ((t (:foreground ,zenburn-yellow :weight bold :underline t))))
 ;;;;; visual-regexp
    `(vr/group-0 ((t (:foreground ,zenburn-bg :background ,zenburn-green :weight bold))))
    `(vr/group-1 ((t (:foreground ,zenburn-bg :background ,zenburn-orange :weight bold))))

--- a/zenburn-theme.el
+++ b/zenburn-theme.el
@@ -199,6 +199,8 @@ Also bind `class' to ((class color) (min-colors 89))."
    `(compilation-mode-line-run ((t (:foreground ,zenburn-yellow :weight bold))))
 ;;;;; completions
    `(completions-annotations ((t (:foreground ,zenburn-fg-1))))
+   `(completions-common-part ((t (:foreground ,zenburn-blue))))
+   `(completions-first-difference ((t (:foreground ,zenburn-fg+1))))
 ;;;;; customize
    `(custom-variable-tag ((t (:foreground ,zenburn-blue :weight bold))))
    `(custom-group-tag ((t (:foreground ,zenburn-blue :weight bold :height 1.2))))


### PR DESCRIPTION
This adds faces for [`vertico`](https://github.com/minad/vertico) and [`orderless`](https://github.com/oantolin/orderless). The face for current selection in `vertico` is made identical to `ivy-current-match`. The faces for `orderless` are selected from the zenburn palette to match the default ones defined in the `orderless`.

Before:
![image](https://user-images.githubusercontent.com/1224535/120584535-2b453f00-c3fe-11eb-93a8-31f944818b14.png)


After:
![image](https://user-images.githubusercontent.com/1224535/120585182-50867d00-c3ff-11eb-97ad-f3eaa0ae604b.png)



-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [x] You've added a before/after screenshot illustrating visually your changes.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality - e.g. theme new faces/packages, changing existing faces, etc)
- [x] You've updated the readme (if adding/changing configuration options)
