### PR TITLE
Add helm-ff-file-extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Changes
+
+* Add `helm-ff-file-extension` face
+
 ## 2.7 (2020-11-21)
 
 ### New features

--- a/zenburn-theme.el
+++ b/zenburn-theme.el
@@ -789,6 +789,7 @@ Also bind `class' to ((class color) (min-colors 89))."
    `(helm-buffer-size ((t (:foreground ,zenburn-fg-1 :background ,zenburn-bg))))
    `(helm-ff-directory ((t (:foreground ,zenburn-cyan :background ,zenburn-bg :weight bold))))
    `(helm-ff-file ((t (:foreground ,zenburn-fg :background ,zenburn-bg :weight normal))))
+   `(helm-ff-file-extension ((t (:foreground ,zenburn-fg :background ,zenburn-bg :weight normal))))
    `(helm-ff-executable ((t (:foreground ,zenburn-green+2 :background ,zenburn-bg :weight normal))))
    `(helm-ff-invalid-symlink ((t (:foreground ,zenburn-red :background ,zenburn-bg :weight bold))))
    `(helm-ff-symlink ((t (:foreground ,zenburn-yellow :background ,zenburn-bg :weight bold))))


### PR DESCRIPTION
Add helm-ff-file-extension face (introduced with Helm v3.6.4) to prevent file extension within helm-find-files defaulting to magenta.
![zenburn-helm](https://user-images.githubusercontent.com/20968004/127980169-d5761655-92af-4c37-a811-29ded245cdfe.png)
