### PR TITLE
Add RMAIL faces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changes
 
 * Add `helm-ff-file-extension` face
+* Add `rmail` support
 
 ## 2.7 (2020-11-21)
 

--- a/zenburn-theme.el
+++ b/zenburn-theme.el
@@ -1372,6 +1372,9 @@ Also bind `class' to ((class color) (min-colors 89))."
    `(realgud-backtrace-number ((t (:foreground ,zenburn-yellow, :weight bold))))
 ;;;;; regex-tool
    `(regex-tool-matched-face ((t (:background ,zenburn-blue-4 :weight bold))))
+;;;;; rmail
+   `(rmail-highlight ((t (:foreground ,zenburn-yellow :weight bold))))
+   `(rmail-header-name ((t (:foreground ,zenburn-blue))))
 ;;;;; rpm-mode
    `(rpm-spec-dir-face ((t (:foreground ,zenburn-green))))
    `(rpm-spec-doc-face ((t (:foreground ,zenburn-green))))


### PR DESCRIPTION
Default face for rmail-header-name is font-lock-function-name-face.

Before:
![zenburn_rmail_before0](https://user-images.githubusercontent.com/1544300/149627496-4b99a36d-722f-46f2-9a40-2f844b0501b9.png)

After:
![zenburn_rmail_after0](https://user-images.githubusercontent.com/1544300/149627506-347a7fe0-f2c3-4c53-a72d-af5a7d215bf2.png)

