### PR TITLE
Adding support for tab-bar-mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Add `helm-ff-file-extension` face
 * Add `rmail` support
+* Add `tab-bar-mode` support
 
 ## 2.7 (2020-11-21)
 

--- a/zenburn-theme.el
+++ b/zenburn-theme.el
@@ -1488,6 +1488,15 @@ Also bind `class' to ((class color) (min-colors 89))."
    `(tabbar-unselected ((t (:foreground ,zenburn-fg
                                         :background ,zenburn-bg+1
                                         :box (:line-width -1 :style released-button)))))
+;;;;; tab-bar
+   `(tab-bar ((t (:background ,zenburn-bg+1))))
+   `(tab-bar-tab ((t (:foreground ,zenburn-fg
+                                  :background ,zenburn-bg
+                                  :weight bold
+                                  :box (:line-width -1 :style released-button)))))
+   `(tab-bar-tab-inactive ((t (:foreground ,zenburn-fg
+                                           :background ,zenburn-bg+1
+                                           :box (:line-width -1 :style released-button)))))
 ;;;;; term
    `(term-color-black ((t (:foreground ,zenburn-bg
                                        :background ,zenburn-bg-1))))


### PR DESCRIPTION
I note that there is already bbatsov/zenburn-emacs#354.  I have kept the same unobtrusive style, using a bold weight to further highlight the active tab.  (I experimented with using green+1 / green-2 ala powerline, but I think I prefer the muted appearance).  I'm also using the box style, similar to the mode-line.

Before:
![image](https://user-images.githubusercontent.com/56747/151686843-d53bc971-2aa0-4b4f-bd18-e8ae0e28c695.png)


After:
![image](https://user-images.githubusercontent.com/56747/151686787-072f64bf-03b2-45df-93a3-aa6ea1e4462c.png)

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [X] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [X] You've added a before/after screenshot illustrating visually your changes.
- [X] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality - e.g. theme new faces/packages, changing existing faces, etc)
- [X] You've updated the readme (if adding/changing configuration options)

Thanks!
