### PR TITLE
Add new flymake color

### DIFF
--- a/zenburn-theme.el
+++ b/zenburn-theme.el
@@ -647,6 +647,21 @@ Also bind `class' to ((class color) (min-colors 89))."
        (:underline (:style wave :color ,zenburn-green)
                    :inherit unspecified :foreground unspecified :background unspecified))
       (t (:foreground ,zenburn-green-2 :weight bold :underline t))))
+   `(flymake-error
+     ((((supports :underline (:style wave)))
+       (:underline (:style wave :color ,zenburn-red)
+                   :inherit unspecified :foreground unspecified :background unspecified))
+      (t (:foreground ,zenburn-red-1 :weight bold :underline t))))
+   `(flymake-warning
+     ((((supports :underline (:style wave)))
+       (:underline (:style wave :color ,zenburn-orange)
+                   :inherit unspecified :foreground unspecified :background unspecified))
+      (t (:foreground ,zenburn-orange :weight bold :underline t))))
+   `(flymake-note
+     ((((supports :underline (:style wave)))
+       (:underline (:style wave :color ,zenburn-green)
+                   :inherit unspecified :foreground unspecified :background unspecified))
+      (t (:foreground ,zenburn-green-2 :weight bold :underline t))))
 ;;;;; flyspell
    `(flyspell-duplicate
      ((((supports :underline (:style wave)))


### PR DESCRIPTION
This PR adds new flymake colors based on the existing legacy flymake color schema:

Before
<img width="322" alt="Screen Shot 2022-04-12 at 12 23 39 PM" src="https://user-images.githubusercontent.com/1224535/163009945-d5c7a225-8a20-442a-9f68-1235b9acbb1c.png">
<img width="247" alt="Screen Shot 2022-04-12 at 12 24 13 PM" src="https://user-images.githubusercontent.com/1224535/163009961-1a6382e4-1aea-4adf-878d-cc5d3ccc14a9.png">
<img width="379" alt="Screen Shot 2022-04-12 at 12 24 36 PM" src="https://user-images.githubusercontent.com/1224535/163009975-f3bea26c-e6bb-4156-bf98-a76f7b670d0a.png">
After
<img width="260" alt="Screen Shot 2022-04-12 at 12 09 47 PM" src="https://user-images.githubusercontent.com/1224535/163010034-679fda42-864e-47e7-9c22-12017e20ccec.png">
<img width="230" alt="Screen Shot 2022-04-12 at 12 19 23 PM" src="https://user-images.githubusercontent.com/1224535/163010055-acc087d8-f790-4af1-80e1-5beb8f75489b.png">
<img width="354" alt="Screen Shot 2022-04-12 at 12 21 53 PM" src="https://user-images.githubusercontent.com/1224535/163010138-41667f41-9beb-443c-af8d-940a4d3d13f4.png">

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [x] You've added a before/after screenshot illustrating visually your changes.
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality - e.g. theme new faces/packages, changing existing faces, etc)
- [ ] You've updated the readme (if adding/changing configuration options)

Thanks!
