### PR TITLE
Add SLY faces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Add `tab-bar-mode` support.
 * [#367](https://github.com/bbatsov/zenburn-emacs/pull/367): Brighten org headline levels 7 and 8 to improve contrast and possibly help those with color blindness.
 * Add support for `ansi-color` faces.
+* Add support for SLY faces.
 
 ## 2.7 (2020-11-21)
 

--- a/zenburn-theme.el
+++ b/zenburn-theme.el
@@ -1486,6 +1486,29 @@ Also bind `class' to ((class color) (min-colors 89))."
       (t
        (:underline ,zenburn-green))))
    `(slime-highlight-face ((t (:inherit highlight))))
+;;;;; SLY
+   `(sly-mrepl-output-face ((t (:foreground ,zenburn-red))))
+   `(sly-error-face
+     ((((supports :underline (:style wave)))
+       (:underline (:style wave :color ,zenburn-red)))
+      (t
+       (:underline ,zenburn-red))))
+   `(sly-warning-face
+     ((((supports :underline (:style wave)))
+       (:underline (:style wave :color ,zenburn-orange)))
+      (t
+       (:underline ,zenburn-orange))))
+   `(sly-style-warning-face
+     ((((supports :underline (:style wave)))
+       (:underline (:style wave :color ,zenburn-yellow)))
+      (t
+       (:underline ,zenburn-yellow))))
+   `(sly-note-face
+     ((((supports :underline (:style wave)))
+       (:underline (:style wave :color ,zenburn-green)))
+      (t
+       (:underline ,zenburn-green))))
+   `(sly-stickers-placed-face ((t (:foreground ,zenburn-fg :background ,zenburn-bg+3))))
 ;;;;; solaire
    `(solaire-default-face ((t (:inherit default :background ,zenburn-bg-08))))
    `(solaire-minibuffer-face ((t (:inherit default :background ,zenburn-bg-08))))


### PR DESCRIPTION
Basic faces are the same as SLIME. For sly-stickers, only
sly-stickers-placed-face needs to be set, as the other ones only inherit from
hi-blue, hi-pink and hi-green.

Before:
![2022-08-23-00_21_39](https://user-images.githubusercontent.com/64833/186029252-56788172-3609-47c1-b148-7757d6d55bf7.png)

After:
![2022-08-23-00_22_21](https://user-images.githubusercontent.com/64833/186029261-fb0db6f2-db00-4881-85f3-74cb5b606ff4.png)



-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [x] You've added a before/after screenshot illustrating visually your changes.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality - e.g. theme new faces/packages, changing existing faces, etc)
- [ ] You've updated the readme (if adding/changing configuration options)

Thanks!
