### PR TITLE
Add tab-line-mode support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Add `helm-ff-file-extension` face.
 * Add `rmail` support.
 * Add `tab-bar-mode` support.
+* Add `tab-line-mode` support.
 * [#367](https://github.com/bbatsov/zenburn-emacs/pull/367): Brighten org headline levels 7 and 8 to improve contrast and possibly help those with color blindness.
 * Add support for `ansi-color` faces.
 * Add support for SLY faces.

--- a/zenburn-theme.el
+++ b/zenburn-theme.el
@@ -1556,6 +1556,18 @@ Also bind `class' to ((class color) (min-colors 89))."
    `(tab-bar-tab-inactive ((t (:foreground ,zenburn-fg
                                            :background ,zenburn-bg+1
                                            :box (:line-width -1 :style released-button)))))
+;;;;; tab-line
+   `(tab-line ((t (:background ,zenburn-bg+1))))
+   `(tab-line-tab ((t (:foreground ,zenburn-fg
+                                  :background ,zenburn-bg
+                                  :weight bold
+                                  :box (:line-width -1 :style released-button)))))
+   `(tab-line-tab-inactive ((t (:foreground ,zenburn-fg
+                                           :background ,zenburn-bg+1
+                                           :box (:line-width -1 :style released-button)))))
+   `(tab-line-tab-current ((t (:foreground ,zenburn-fg
+                                           :background ,zenburn-bg+1
+                                           :box (:line-width -1 :style pressed-button)))))
 ;;;;; term
    `(term-color-black ((t (:foreground ,zenburn-bg
                                        :background ,zenburn-bg-1))))


### PR DESCRIPTION
Adds basic support for tab-line-mode. Uses the same styling as tab-bar-mode.


Before:
![image](https://user-images.githubusercontent.com/1012677/188199020-5489865b-5f85-4556-b22f-33c0227d3db3.png)
After:
![image](https://user-images.githubusercontent.com/1012677/188198619-03df185f-c29b-4c5b-bf04-8b5f55685d1f.png)

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [X] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [X] You've added a before/after screenshot illustrating visually your changes.
- [X] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality - e.g. theme new faces/packages, changing existing faces, etc)
- [X] You've updated the readme (if adding/changing configuration options)

Thanks!
