### PR TITLE
Update tab-bar and tab-line style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Add `helm-ff-file-extension` face.
 * Add `rmail` support.
 * Add `tab-bar-mode` support.
+* Add `tab-line-mode` support.
 * [#367](https://github.com/bbatsov/zenburn-emacs/pull/367): Brighten org headline levels 7 and 8 to improve contrast and possibly help those with color blindness.
 * Add support for `ansi-color` faces.
 * Add support for SLY faces.

--- a/zenburn-theme.el
+++ b/zenburn-theme.el
@@ -1549,25 +1549,36 @@ Also bind `class' to ((class color) (min-colors 89))."
                                         :box (:line-width -1 :style released-button)))))
 ;;;;; tab-bar
    `(tab-bar ((t (:background ,zenburn-bg+1))))
-   `(tab-bar-tab ((t (:foreground ,zenburn-fg
-                                  :background ,zenburn-bg
-                                  :weight bold
-                                  :box (:line-width -1 :style released-button)))))
-   `(tab-bar-tab-inactive ((t (:foreground ,zenburn-fg
-                                           :background ,zenburn-bg+1
-                                           :box (:line-width -1 :style released-button)))))
+   `(tab-bar-tab
+     ((t (:foreground ,zenburn-fg
+                      :background ,zenburn-bg
+                      :weight bold
+                      :height 1.1
+                      :box (:line-width (6 . 4) :color ,zenburn-bg :style nil)))))
+   `(tab-bar-tab-inactive
+     ((t (:foreground ,zenburn-fg
+                      :background ,zenburn-bg+1
+                      :height 1.1
+                      :box (:line-width (6 . 4) :color ,zenburn-bg+1 :style nil)))))
 ;;;;; tab-line
    `(tab-line ((t (:background ,zenburn-bg+1))))
-   `(tab-line-tab ((t (:foreground ,zenburn-fg
-                                  :background ,zenburn-bg
-                                  :weight bold
-                                  :box (:line-width -1 :style released-button)))))
-   `(tab-line-tab-inactive ((t (:foreground ,zenburn-fg
-                                           :background ,zenburn-bg+1
-                                           :box (:line-width -1 :style released-button)))))
-   `(tab-line-tab-current ((t (:foreground ,zenburn-fg
-                                           :background ,zenburn-bg+1
-                                           :box (:line-width -1 :style pressed-button)))))
+   `(tab-line-tab
+     ((t (:foreground ,zenburn-fg
+                      :background ,zenburn-bg+1
+                      :box (:line-width (6 . 4) :color ,zenburn-bg+1 :style nil)))))
+   `(tab-line-tab-inactive
+     ((t (:foreground ,zenburn-fg
+                      :background ,zenburn-bg+1
+                      :box (:line-width (6 . 4) :color ,zenburn-bg+1 :style nil)))))
+   `(tab-line-tab-current
+     ((t (:foreground ,zenburn-fg
+                      :background ,zenburn-bg
+                      :weight bold
+                      :box (:line-width (6 . 4) :color ,zenburn-bg :style nil)))))
+   `(tab-line-highlight
+     ((t (:foreground ,zenburn-fg
+                      :background ,zenburn-bg+2
+                      :box (:line-width (6 . 4) :color ,zenburn-bg+2 :style nil)))))
 ;;;;; term
    `(term-color-black ((t (:foreground ,zenburn-bg
                                        :background ,zenburn-bg-1))))
@@ -1700,6 +1711,12 @@ Also bind `class' to ((class color) (min-colors 89))."
        ,zenburn-cyan ,zenburn-blue+1 ,zenburn-magenta))
 ;;;;; pdf-tools
    `(pdf-view-midnight-colors '(,zenburn-fg . ,zenburn-bg-05))
+;;;;; tab-bar
+   ;; For some reason, the padding doesn't display properly if the
+   ;; tab-bar-separator is "", swe we use a zero-width space instead
+   `(tab-bar-separator "\u200b")
+;;;;; tab-line
+   `(tab-line-separator "")
 ;;;;; vc-annotate
    `(vc-annotate-color-map
      '(( 20. . ,zenburn-red-1)

--- a/zenburn-theme.el
+++ b/zenburn-theme.el
@@ -1556,6 +1556,18 @@ Also bind `class' to ((class color) (min-colors 89))."
    `(tab-bar-tab-inactive ((t (:foreground ,zenburn-fg
                                            :background ,zenburn-bg+1
                                            :box (:line-width -1 :style released-button)))))
+;;;;; tab-line
+   `(tab-line ((t (:background ,zenburn-bg+1))))
+   `(tab-line-tab ((t (:foreground ,zenburn-fg
+                                  :background ,zenburn-bg
+                                  :weight bold
+                                  :box (:line-width -1 :style released-button)))))
+   `(tab-line-tab-inactive ((t (:foreground ,zenburn-fg
+                                           :background ,zenburn-bg+1
+                                           :box (:line-width -1 :style released-button)))))
+   `(tab-line-tab-current ((t (:foreground ,zenburn-fg
+                                           :background ,zenburn-bg+1
+                                           :box (:line-width -1 :style pressed-button)))))
 ;;;;; term
    `(term-color-black ((t (:foreground ,zenburn-bg
                                        :background ,zenburn-bg-1))))


### PR DESCRIPTION
While https://github.com/bbatsov/zenburn-emacs/pull/371 was meant to be a non-controversial change, making the tab-line style consistent with tab-bar, this PR updates the styles of both to look "better" (in my opinion). The changes include:
- Make the tab-bar font size slightly bigger to improve readability
- Add padding around the tab text
- Change the box style from released/pressed button to nil, for a more flat, modern look.
- Removed the separators between tabs (note that for some reason, the only way to do this and preserve the padding with tab-bar is to use a zero-width space)

After:
![image](https://user-images.githubusercontent.com/1012677/188230764-f20751b0-2587-4e90-bd2a-3f6126924f80.png)
-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [X] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [X] You've added a before/after screenshot illustrating visually your changes.
- [X] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality - e.g. theme new faces/packages, changing existing faces, etc)
- [X] You've updated the readme (if adding/changing configuration options)

Thanks!
