### PR TITLE
Make region color little more lighter

### DIFF
--- a/zenburn-theme.el
+++ b/zenburn-theme.el
@@ -262,7 +262,7 @@ Also bind `class' to ((class color) (min-colors 89))."
      ((t (:foreground ,zenburn-green-2
                       :background ,zenburn-bg-05
                       :box (:line-width -1 :style released-button)))))
-   `(region ((,class (:background ,zenburn-bg-1 :extend t))
+   `(region ((,class (:background ,zenburn-bg+2 :extend t))
              (t :inverse-video t)))
    `(secondary-selection ((t (:background ,zenburn-bg+2))))
    `(trailing-whitespace ((t (:background ,zenburn-red))))


### PR DESCRIPTION
I feel like the highlight color and region color are almost similar. Therefore cannot clearly see the region selected if I am on a highlight. 

Here is the screenshot of the current region selection color. Here I have selected the word `zenburn-bg-05` . But I am unable to understand whether the region is selected or not. 
<img width="735" alt="Screenshot 2024-05-25 at 4 49 14 PM" src="https://github.com/bbatsov/zenburn-emacs/assets/68493371/f5111336-9ed7-421b-8830-64f175ed212a">


Here is the screenshot of my pruposed change. I feel like bit more lighter color would be good to identify the selected region from the highlight.

<img width="624" alt="Screenshot 2024-05-25 at 4 54 49 PM" src="https://github.com/bbatsov/zenburn-emacs/assets/68493371/13f35782-c914-46b4-a8cb-fecc308c36e2">

If you did not like the color, I can change to the color you think would be better. But I would suggest there should be a clear contrast difference between highlight and region colors. 

PS: I am not sure how to update changelog. Sorry!
-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [X] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [X] You've added a before/after screenshot illustrating visually your changes.
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality - e.g. theme new faces/packages, changing existing faces, etc)
- [ ] You've updated the readme (if adding/changing configuration options)

Thanks!
