### PR TITLE
Add support for window-tool-bar, added in Emacs 30.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New features
 
 * Add `corfu` support.
+* Add `window-tool-bar` support.
 
 ## 2.8 (2023-03-15)
 

--- a/zenburn-theme.el
+++ b/zenburn-theme.el
@@ -1693,6 +1693,16 @@ Also bind `class' to ((class color) (min-colors 89))."
    `(wl-highlight-summary-displaying-face ((t (:underline t :weight bold))))
 ;;;;; which-func-mode
    `(which-func ((t (:foreground ,zenburn-green+4))))
+;;;;; window-tool-bar-mode
+   `(window-tool-bar-button ((t (:foreground ,zenburn-fg
+                                 :background ,zenburn-bg
+                                 :box (:line-width -1 :style released-button)))))
+   `(window-tool-bar-button-hover ((t (:foreground ,zenburn-fg
+                                       :background ,zenburn-bg+1
+                                       :box (:line-width -1 :style released-button)))))
+   `(window-tool-bar-button-disabled ((t (:foreground ,zenburn-fg
+                                          :background ,zenburn-bg+3
+                                          :box (:line-width -1 :style released-button)))))
 ;;;;; xcscope
    `(cscope-file-face ((t (:foreground ,zenburn-yellow :weight bold))))
    `(cscope-function-face ((t (:foreground ,zenburn-cyan :weight bold))))


### PR DESCRIPTION
I am the author of the "window-tool-bar" package which was recently added to Emacs 30. I'm now chasing down popular themes so that it looks good when Emacs 30 is released.

-----------------

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [x] You've added a before/after screenshot illustrating visually your changes.
    * Before: ![before](https://github.com/bbatsov/zenburn-emacs/assets/9546385/b6929cbe-d7d1-452a-b8e0-1c4085be0840)
    * After: ![after](https://github.com/bbatsov/zenburn-emacs/assets/9546385/68beefdd-b484-4011-b117-304ae0c76d24)
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality - e.g. theme new faces/packages, changing existing faces, etc)
- [x] You've updated the readme (if adding/changing configuration options)
    * Note: No configuration added