### PR TITLE
Add explicit helm-grep-match face definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+* [#635eeec](https://github.com/wilya7/zenburn-emacs/commit/635eeecf04ae162b41e1b6c1e596e608f1b30746): Fix warning for helm-grep-match face by adding explicit face definition.
+
 ### New features
 
 * Add `corfu` support.

--- a/zenburn-theme.el
+++ b/zenburn-theme.el
@@ -859,7 +859,7 @@ Also bind `class' to ((class color) (min-colors 89))."
    `(helm-grep-file ((t (:foreground ,zenburn-fg :background ,zenburn-bg))))
    `(helm-grep-finish ((t (:foreground ,zenburn-green+2 :background ,zenburn-bg))))
    `(helm-grep-lineno ((t (:foreground ,zenburn-fg-1 :background ,zenburn-bg))))
-   `(helm-grep-match ((t (:foreground unspecified :background unspecified :inherit helm-match))))
+   `(helm-grep-match ((t (:foreground ,zenburn-yellow :background ,zenburn-bg-1 :weight bold))))
    `(helm-grep-running ((t (:foreground ,zenburn-red :background ,zenburn-bg))))
    `(helm-match ((t (:foreground ,zenburn-orange :background ,zenburn-bg-1 :weight bold))))
    `(helm-moccur-buffer ((t (:foreground ,zenburn-cyan :background ,zenburn-bg))))


### PR DESCRIPTION
This pull request addresses a warning that occurs when using the Zenburn theme with Helm:

```
Warning: setting attribute ':background' of face 'helm-grep-match': nil value is invalid, use 'unspecified' instead.
Warning: setting attribute ':foreground' of face 'helm-grep-match': nil value is invalid, use 'unspecified' instead.
```

To resolve this, I've added an explicit definition for the `helm-grep-match` face:

```elisp
`(helm-grep-match ((t (:foreground ,zenburn-yellow :background ,zenburn-bg-1 :weight bold))))
```
This change:

1. Explicitly sets the foreground, background, and weight properties
2. Uses Zenburn theme color variables for consistency

This fix eliminates the warning and ensures the face is styled consistently with the Zenburn theme aesthetics.

I've also updated the CHANGELOG.md to reflect this change.

-----------------
- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've added a before/after screenshot illustrating visually your changes.
- [x] You've updated the [changelog](https://github.com/wilya7/zenburn-emacs/blob/f097cd336fd10dbceba00a92e469d9d8b0d3b44e/CHANGELOG.md) (if adding/changing user-visible functionality - e.g. theme new faces/packages, changing existing faces, etc)
- [ ] I have updated the readme (if adding/changing configuration options)