### PR TITLE
Add gptel face support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* [#388](https://github.com/bbatsov/zenburn-emacs/pull/388): Add face support for gptel.
 * [#387](https://github.com/bbatsov/zenburn-emacs/pull/387): Add face support for asciidoc-mode, vundo, easy-kill, clojure-mode, copilot, git-timemachine, haskell-mode, keycast, dictionary, mistty, erlang and inf-ruby.
 * [#387](https://github.com/bbatsov/zenburn-emacs/pull/387): Deepen cider coverage with the REPL, stacktrace and inline error faces, plus faces for the nREPL message log.
 

--- a/test/zenburn-test.el
+++ b/test/zenburn-test.el
@@ -212,7 +212,10 @@ frame-side face recomputation (which is unreliable in batch)."
             erlang-edoc-verbatim erlang-edoc-todo)
     (git-timemachine git-timemachine-commit
                      git-timemachine-minibuffer-author-face
-                     git-timemachine-minibuffer-detail-face))
+                     git-timemachine-minibuffer-detail-face)
+    (gptel gptel-context-highlight-face gptel-context-deletion-face
+           gptel-rewrite-highlight-face gptel-response-highlight
+           gptel-response-fringe-highlight))
   "Alist of (PACKAGE . FACES) the theme is expected to cover.")
 
 (describe "package face coverage"

--- a/zenburn-theme.el
+++ b/zenburn-theme.el
@@ -1146,6 +1146,12 @@ the just-introduced bindings."
    `(mm-uu-extract ((t (:background ,zenburn-bg-05 :foreground ,zenburn-green+1))))
 ;;;;; go-guru
    `(go-guru-hl-identifier-face ((t (:foreground ,zenburn-bg-1 :background ,zenburn-green+1))))
+;;;;; gptel
+   `(gptel-context-highlight-face ((t (:background ,zenburn-bg+05 :extend t))))
+   `(gptel-context-deletion-face ((t (:background ,zenburn-diff-removed-bg :extend t))))
+   `(gptel-rewrite-highlight-face ((t (:background ,zenburn-diff-changed-bg :extend t))))
+   `(gptel-response-highlight ((t (:background ,zenburn-bg-05 :extend t))))
+   `(gptel-response-fringe-highlight ((t (:foreground ,zenburn-blue))))
 ;;;;; hackernews
    '(hackernews-comment-count ((t (:inherit link-visited :underline nil))))
    '(hackernews-link          ((t (:inherit link         :underline nil))))


### PR DESCRIPTION
gptel bakes hardcoded backgrounds (gray4, gray14, #041714) into its faces, which clash with Zenburn. Maps the context and response regions to the subtle bg lifts and the deletion/rewrite highlights to the tinted diff backgrounds. breadcrumb was already covered here. Guarded by a face-coverage test.