### PR TITLE
Fix byte compile warnings

### DIFF
--- a/zenburn-theme.el
+++ b/zenburn-theme.el
@@ -225,21 +225,19 @@ Bindings are introduced in order: positional palette first (from
 reference positional palette names as symbols, which resolve against
 the just-introduced bindings."
   (declare (indent 0))
-  `(let* (,@(mapcar (lambda (cons)
-                      (list (intern (car cons)) (cdr cons)))
-                    (append zenburn-default-colors-alist
-                            zenburn-override-colors-alist))
-          ,@(mapcar (lambda (cons)
-                      (list (intern (car cons)) (cdr cons)))
-                    (append zenburn-default-semantic-colors-alist
-                            zenburn-override-semantic-colors-alist)))
-     ;; Silence the byte compiler.
-     (ignore ,@(mapcar (lambda (cons) (intern (car cons)))
-                       (append zenburn-default-colors-alist
-                               zenburn-override-colors-alist
-                               zenburn-default-semantic-colors-alist
-                               zenburn-override-semantic-colors-alist)))
-     ,@body))
+  (let (sym val binds vars)
+    (dolist (cons (append zenburn-default-colors-alist
+                          zenburn-override-colors-alist
+                          zenburn-default-semantic-colors-alist
+                          zenburn-override-semantic-colors-alist))
+      (setq sym (intern (car cons))
+            val (cdr cons))
+      (push (list sym val) binds)
+      (push sym vars))
+    `(let* (,@(nreverse binds))
+       ;; Silence the byte compiler.
+       (ignore ,@(nreverse vars))
+       ,@body)))
 
 ;;; Theme Faces
 (zenburn-with-color-variables

--- a/zenburn-theme.el
+++ b/zenburn-theme.el
@@ -233,6 +233,12 @@ the just-introduced bindings."
                       (list (intern (car cons)) (cdr cons)))
                     (append zenburn-default-semantic-colors-alist
                             zenburn-override-semantic-colors-alist)))
+     ;; Silence the byte compiler.
+     (ignore ,@(mapcar (lambda (cons) (intern (car cons)))
+                       (append zenburn-default-colors-alist
+                               zenburn-override-colors-alist
+                               zenburn-default-semantic-colors-alist
+                               zenburn-override-semantic-colors-alist)))
      ,@body))
 
 ;;; Theme Faces


### PR DESCRIPTION
* zenburn-theme.el (zenburn-with-color-variables): Add a no-op `ignore` form.