### PR TITLE
Fix invalid doom-modeline inactive bar background

### DIFF
--- a/zenburn-theme.el
+++ b/zenburn-theme.el
@@ -822,7 +822,7 @@ the just-introduced bindings."
    `(doom-modeline-notification ((t (:foreground ,zenburn-orange))))
    `(doom-modeline-unread-number ((t (:foreground ,zenburn-fg :weight bold))))
    `(doom-modeline-bar ((t (:background ,zenburn-yellow))))
-   `(doom-modeline-bar-inactive ((t (:background nil))))
+   `(doom-modeline-bar-inactive ((t (:background unspecified))))
    `(doom-modeline-evil-emacs-state ((t (:foreground ,zenburn-magenta :weight bold))))
    `(doom-modeline-evil-insert-state ((t (:foreground ,zenburn-green :weight bold))))
    `(doom-modeline-evil-motion-state ((t (:foreground ,zenburn-blue :weight bold))))


### PR DESCRIPTION
Use unspecified instead of nil for the doom-modeline inactive bar background, this avoids face attribute warnings in emacs 31.

-----------------

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)

These were not done because no changes should be visible to the user:
- [ ] You've added a before/after screenshot illustrating visually your changes.
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality - e.g. theme new faces/packages, changing existing faces, etc) 
- [ ] You've updated the readme (if adding/changing configuration options)
