### PR TITLE
Add term-color-bright-* faces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## master (unreleased)
+
+### New features
+
+* Add the eight `term-color-bright-*` faces (Emacs 28+).
+
 ## 2.11.0 (2026-07-26)
 
 ### New features

--- a/zenburn-theme.el
+++ b/zenburn-theme.el
@@ -2073,6 +2073,28 @@ the just-introduced bindings."
                                       :background ,zenburn-blue))))
    `(term-color-white ((t (:foreground ,zenburn-fg
                                        :background ,zenburn-fg-1))))
+   ;; The bright faces exist since Emacs 28. Without them the bright half of
+   ;; the palette falls back to stock ANSI. Each bright is one palette step above
+   ;; its non-bright counterpart, so the second tier reads as emphasis without
+   ;; leaving Zenburn's low-contrast range.
+   `(term-color-bright-black ((t (:foreground ,zenburn-bg+3
+                                              :background ,zenburn-bg+3))))
+   `(term-color-bright-red ((t (:foreground ,zenburn-red
+                                            :background ,zenburn-red))))
+   `(term-color-bright-green ((t (:foreground ,zenburn-green+1
+                                              :background ,zenburn-green+1))))
+   `(term-color-bright-yellow ((t (:foreground ,zenburn-yellow-1
+                                               :background ,zenburn-yellow-1))))
+   `(term-color-bright-blue ((t (:foreground ,zenburn-blue
+                                             :background ,zenburn-blue))))
+   ;; Zenburn has a single magenta, so the bright slot borrows red+1 rather
+   ;; than repeating `zenburn-magenta' and losing the distinction.
+   `(term-color-bright-magenta ((t (:foreground ,zenburn-red+1
+                                                :background ,zenburn-red+1))))
+   `(term-color-bright-cyan ((t (:foreground ,zenburn-blue+2
+                                             :background ,zenburn-blue+2))))
+   `(term-color-bright-white ((t (:foreground ,zenburn-fg+1
+                                              :background ,zenburn-fg+1))))
    '(term-default-fg-color ((t (:inherit term-color-white))))
    '(term-default-bg-color ((t (:inherit term-color-black))))
 ;;;;; undo-tree


### PR DESCRIPTION
term.el has defined the eight bright ANSI faces since Emacs 28, but only the non-bright half was themed, so bright colors fell back to stock ANSI which were way too bright.

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've added a before/after screenshot illustrating visually your changes.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality - e.g. theme new faces/packages, changing existing faces, etc)
- [ ] You've updated the readme (if adding/changing configuration options)

Thanks!
