### PR TITLE
Make low-contrast faces readable and guard against new ones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## master (unreleased)
+
+### Bug fixes
+
+* [#393](https://github.com/bbatsov/zenburn-emacs/pull/393): Make face text readable on its own background: `whitespace-indentation` and `whitespace-space-after-tab` were red on yellow at 1.95:1, and `show-paren-mismatch` red on a grey lift at 2.35:1.
+* [#393](https://github.com/bbatsov/zenburn-emacs/pull/393): Give `ediff-fine-diff-B` dark text, its background being the one light enough to need it.
+
 ## 2.11.0 (2026-07-26)
 
 ### New features

--- a/test/zenburn-test.el
+++ b/test/zenburn-test.el
@@ -20,6 +20,43 @@
   (add-to-list 'custom-theme-load-path
                (expand-file-name ".." dir)))
 
+(defconst zenburn-test--source-file
+  (expand-file-name
+   "../zenburn-theme.el"
+   (file-name-directory (or load-file-name buffer-file-name default-directory)))
+  "Path to the theme source, for the checks that read it as text.")
+
+(defun zenburn-test--hex-p (color)
+  "Return non-nil if COLOR is a six-digit hex string.
+A few faces use named colors such as \"grey70\", which we can't measure
+without a display, so they sit outside the contrast checks."
+  (and (stringp color) (string-match-p "\\`#[0-9a-fA-F]\\{6\\}\\'" color)))
+
+(defun zenburn-test--luminance (hex)
+  "Return the WCAG relative luminance of the color HEX."
+  (let ((channels (mapcar
+                   (lambda (offset)
+                     (let ((v (/ (string-to-number
+                                  (substring hex offset (+ offset 2)) 16)
+                                 255.0)))
+                       (if (<= v 0.04045) (/ v 12.92)
+                         (expt (/ (+ v 0.055) 1.055) 2.4))))
+                   '(1 3 5))))
+    (+ (* 0.2126 (nth 0 channels))
+       (* 0.7152 (nth 1 channels))
+       (* 0.0722 (nth 2 channels)))))
+
+(defun zenburn-test--contrast (a b)
+  "Return the WCAG contrast ratio between the colors A and B."
+  (let* ((la (zenburn-test--luminance a))
+         (lb (zenburn-test--luminance b))
+         (lighter (max la lb)) (darker (min la lb)))
+    (/ (+ lighter 0.05) (+ darker 0.05))))
+
+(defun zenburn-test--color (name)
+  "Return NAME's value from the default palette."
+  (cdr (assoc name zenburn-default-colors-alist)))
+
 (defun zenburn-test--reload ()
   "Disable and (re-)load the Zenburn theme.
 Reloading re-evaluates the theme file, which picks up any let-bound
@@ -231,5 +268,129 @@ frame-side face recomputation (which is unreliable in batch)."
         (dolist (face faces)
           (expect (assq 'zenburn (get face 'theme-face))
                   :to-be-truthy))))))
+;;; Text has to be readable on its own background
+
+(defconst zenburn-test--legibility-floor 3.0
+  "Contrast a face's own text must reach against its own background.")
+
+(defconst zenburn-test--legibility-exceptions
+  '(;; the cursor's background is the cursor, not a backdrop for text
+    cursor
+    ;; fringe and margin indicators, drawn as a glyph or a bar rather than
+    ;; text on a background
+    diff-hl-change diff-hl-delete diff-hl-insert
+    bm-fringe-persistent-face bm-persistent-face ctbl:face-continue-bar
+    ;; deliberately receding chrome
+    line-number mode-line-inactive hydra-face-amaranth
+    ;; diff and merge tints, where the background carries the meaning
+    diff-added diff-removed diff-refine-changed smerge-refined-changed
+    ediff-fine-diff-A ediff-fine-diff-Ancestor ediff-fine-diff-C
+    isearch-group-1 neo-vc-unlocked-changes-face)
+  "Faces allowed below `zenburn-test--legibility-floor'.
+Each is a deliberate choice rather than an oversight: a cursor, a fringe
+glyph, chrome that is supposed to recede, or a tint whose background does
+the talking.  Anything arriving here new should be argued for.")
+
+(describe "text on its own background"
+  (before-each (zenburn-test--reload))
+
+  (it "stays readable"
+    (let ((illegible '()))
+      (mapatoms
+       (lambda (sym)
+         (let ((fg (zenburn-test--face-attr sym :foreground))
+               (bg (zenburn-test--face-attr sym :background)))
+           (when (and (zenburn-test--hex-p fg) (zenburn-test--hex-p bg)
+                      ;; ansi and term color faces set both alike on purpose,
+                      ;; and so do the whitespace block markers, which mark a
+                      ;; region with a color rather than a glyph
+                      (not (string-equal (upcase fg) (upcase bg)))
+                      (not (string-match-p "\\`\\(ansi\\|term\\)-color-" (symbol-name sym)))
+                      ;; the two foregrounds Zenburn hands to de-emphasized text
+                      (not (member (upcase fg)
+                                   (list (upcase (zenburn-test--color "zenburn-fg-1"))
+                                         (upcase (zenburn-test--color "zenburn-fg-05")))))
+                      (not (memq sym zenburn-test--legibility-exceptions))
+                      (< (zenburn-test--contrast fg bg) zenburn-test--legibility-floor))
+             (push (list sym (zenburn-test--contrast fg bg)) illegible)))))
+      (expect illegible :to-equal '()))))
+
+;;; The shape of the source itself
+
+(defun zenburn-test--face-body ()
+  "Return the part of the source holding the face definitions."
+  (with-temp-buffer
+    (insert-file-contents zenburn-test--source-file)
+    (goto-char (point-min))
+    (search-forward "custom-theme-set-faces")
+    (buffer-substring-no-properties (point) (point-max))))
+
+(defun zenburn-test--matches (regexp string &optional group)
+  "Return every GROUP match of REGEXP in STRING."
+  (let ((start 0) (found '()))
+    (while (string-match regexp string start)
+      (push (match-string (or group 1) string) found)
+      (setq start (match-end 0)))
+    (nreverse found)))
+
+(describe "the source"
+  (it "defines each face exactly once"
+    (let* ((faces (zenburn-test--matches
+                   "`(\\([^ ()]+\\) ((t (" (zenburn-test--face-body)))
+           (seen (make-hash-table :test 'equal)) (dupes '()))
+      (dolist (face faces)
+        (when (gethash face seen) (push face dupes))
+        (puthash face t seen))
+      (expect (delete-dups dupes) :to-equal '())))
+
+  (it "only refers to colors the palette defines"
+    (let* ((defined (append (mapcar #'car zenburn-default-colors-alist)
+                            (mapcar #'car zenburn-default-semantic-colors-alist)))
+           (used (delete-dups (zenburn-test--matches
+                               ",\\(zenburn-[a-z0-9+-]+\\)" (zenburn-test--face-body)))))
+      (expect (seq-remove (lambda (name)
+                            (or (member name defined)
+                                ;; the theme also binds a few non-palette locals
+                                (string-prefix-p "zenburn-test" name)))
+                          used)
+              :to-equal '()))))
+
+;;; Package headers
+
+(describe "package headers"
+  (it "opens with a summary and a lexical-binding cookie"
+    (let ((first-line (with-temp-buffer
+                        (insert-file-contents zenburn-test--source-file)
+                        (buffer-substring-no-properties
+                         (point-min) (line-end-position)))))
+      (expect first-line :to-match
+              (rx-to-string '(seq ";;; " (1+ nonl) " --- " (1+ nonl)
+                                  "-*- lexical-binding: t" (opt ";") " -*-")))))
+
+  (it "declares the headers a package needs"
+    (let ((text (with-temp-buffer
+                  (insert-file-contents zenburn-test--source-file)
+                  (buffer-string))))
+      ;; no Package-Requires here: the theme has never declared one, so
+      ;; there is no stated minimum Emacs version to check against
+      (dolist (header '("Author" "URL" "Version"))
+        (expect (string-match-p (concat "^;; " header ": ") text) :not :to-be nil)))))
+
+;;; Emphasis restraint
+
+(describe "emphasis"
+  (before-each (zenburn-test--reload))
+
+  (it "never stacks three emphasis attributes on one face"
+    (let ((overwrought '()))
+      (mapatoms
+       (lambda (sym)
+         (when (assoc 'zenburn (get sym 'theme-face))
+           (when (> (seq-count (lambda (attr) (zenburn-test--face-attr sym attr))
+                               '(:weight :slant :underline :box :overline :strike-through))
+                    2)
+             (unless (memq sym '(cscope-separator-face))
+               (push sym overwrought))))))
+      (expect overwrought :to-equal '()))))
 
 ;;; zenburn-test.el ends here

--- a/test/zenburn-test.el
+++ b/test/zenburn-test.el
@@ -367,6 +367,13 @@ the talking.  Anything arriving here new should be argued for.")
               (rx-to-string '(seq ";;; " (1+ nonl) " --- " (1+ nonl)
                                   "-*- lexical-binding: t" (opt ";") " -*-")))))
 
+  (it "keeps the summary to MELPA's conventions"
+    (let ((summary (with-temp-buffer
+                     (insert-file-contents zenburn-test--source-file)
+                     (buffer-substring-no-properties (point-min) (line-end-position)))))
+      (expect summary :not :to-match "for Emacs")
+      (expect summary :not :to-match (rx "." (0+ blank) "-*-"))))
+
   (it "declares the headers a package needs"
     (let ((text (with-temp-buffer
                   (insert-file-contents zenburn-test--source-file)

--- a/zenburn-theme.el
+++ b/zenburn-theme.el
@@ -872,7 +872,7 @@ the just-introduced bindings."
    `(ediff-even-diff-C ((t (:background ,zenburn-bg+1))))
    `(ediff-fine-diff-A ((t (:foreground ,zenburn-fg :background ,zenburn-red-2 :weight bold))))
    `(ediff-fine-diff-Ancestor ((t (:foreground ,zenburn-fg :background ,zenburn-red-2 :weight bold))))
-   `(ediff-fine-diff-B ((t (:foreground ,zenburn-fg :background ,zenburn-green :weight bold))))
+   `(ediff-fine-diff-B ((t (:foreground ,zenburn-bg :background ,zenburn-green :weight bold))))
    `(ediff-fine-diff-C ((t (:foreground ,zenburn-fg :background ,zenburn-blue-3 :weight bold ))))
    `(ediff-odd-diff-A ((t (:background ,zenburn-bg+2))))
    `(ediff-odd-diff-Ancestor ((t (:background ,zenburn-bg+2))))
@@ -1858,7 +1858,7 @@ the just-introduced bindings."
    `(sh-heredoc     ((t (:foreground ,zenburn-yellow :weight bold))))
    `(sh-quoted-exec ((t (:foreground ,zenburn-red))))
 ;;;;; show-paren
-   `(show-paren-mismatch ((t (:foreground ,zenburn-red+1 :background ,zenburn-bg+3 :weight bold))))
+   `(show-paren-mismatch ((t (:foreground ,zenburn-fg+1 :background ,zenburn-red-4 :weight bold))))
    `(show-paren-match ((t (:foreground ,zenburn-fg :background ,zenburn-bg+3 :weight bold))))
 ;;;;; smart-mode-line
    ;; use (setq sml/theme nil) to enable Zenburn for sml
@@ -1880,7 +1880,7 @@ the just-introduced bindings."
    `(sml/charging ((t (:foreground ,zenburn-green+4))))
    `(sml/discharging ((t (:foreground ,zenburn-red+1))))
 ;;;;; smartparens
-   `(sp-show-pair-mismatch-face ((t (:foreground ,zenburn-red+1 :background ,zenburn-bg+3 :weight bold))))
+   `(sp-show-pair-mismatch-face ((t (:foreground ,zenburn-fg+1 :background ,zenburn-red-4 :weight bold))))
    `(sp-show-pair-match-face ((t (:background ,zenburn-bg+3 :weight bold))))
 ;;;;; smerge
    `(smerge-base ((t (:background "#555511" :extend t))))
@@ -2136,9 +2136,9 @@ the just-introduced bindings."
    `(whitespace-trailing ((t (:background ,zenburn-red))))
    `(whitespace-line ((t (:background ,zenburn-bg :foreground ,zenburn-magenta))))
    `(whitespace-space-before-tab ((t (:background ,zenburn-orange :foreground ,zenburn-orange))))
-   `(whitespace-indentation ((t (:background ,zenburn-yellow :foreground ,zenburn-red))))
+   `(whitespace-indentation ((t (:background ,zenburn-yellow :foreground ,zenburn-bg))))
    `(whitespace-empty ((t (:background ,zenburn-yellow))))
-   `(whitespace-space-after-tab ((t (:background ,zenburn-yellow :foreground ,zenburn-red))))
+   `(whitespace-space-after-tab ((t (:background ,zenburn-yellow :foreground ,zenburn-bg))))
 ;;;;; wanderlust
    `(wl-highlight-folder-few-face ((t (:foreground ,zenburn-red-2))))
    `(wl-highlight-folder-many-face ((t (:foreground ,zenburn-red-1))))

--- a/zenburn-theme.el
+++ b/zenburn-theme.el
@@ -1,4 +1,4 @@
-;;; zenburn-theme.el --- A low contrast color theme for Emacs.  -*- lexical-binding: t -*-
+;;; zenburn-theme.el --- A low contrast color theme  -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2011-2026 Bozhidar Batsov
 


### PR DESCRIPTION
The audit I ran over tokyo-night and batppuccin, applied here.

**Text that could not be read on its own background.**
`whitespace-indentation` and `whitespace-space-after-tab` drew red on yellow at
1.95:1. `show-paren-mismatch` was red on a grey lift at 2.35:1, which is a thin
showing for the one face whose entire job is to shout, so it now gets the red
block Emacs uses by default, with `sp-show-pair-mismatch-face` kept in step.
`ediff-fine-diff-B` is the single ediff background light enough to need dark
text.

The suite goes from 14 specs to 21: a contrast floor, guards over the shape of
the source, package headers, and DESIGN-style emphasis restraint.

Writing those checks turned up three things about this theme worth recording,
all of which they now accommodate rather than flag:

Some faces use named colors such as `grey70`, which can't be measured without a
display, so they sit outside the contrast check. The theme draws on a semantic
palette as well as the base one, so "only refers to colors the palette defines"
has to consult both. And `cscope-separator-face` stacks bold, underline and
overline deliberately, because it draws a rule rather than styling text.

The exception list in the contrast check is explicit and argued: a cursor,
fringe glyphs, chrome meant to recede, and diff tints where the background does
the talking. Anything arriving there new should have to justify itself.

One finding I have not acted on, because it is a support-policy call rather than
a bug: there is no `Package-Requires` header at all, so the package declares no
minimum Emacs version. package-lint notices, since `lexical-binding` alone
implies 24.1. CI builds 27.1 through snapshot, and the source uses nothing
newer than that, so either 24.1 or 27.1 would be defensible; picking one is
yours. The header test checks Author, URL and Version and deliberately leaves
Package-Requires out until that is settled.